### PR TITLE
Load ChatListItem details when only ID provided

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -30,7 +30,7 @@ export const ChatList = (props: MgtTemplateProps & IChatListItemInteractionProps
     <FluentThemeProvider fluentTheme={FluentTheme}>
       <FluentProvider theme={webLightTheme}>
         {chats.map(c => (
-          <ChatListItem key={c.id} chat={c} myId={chatState.userId} onSelected={props.onSelected} />
+          <ChatListItem key={c.id} chat={{ id: c.id }} myId={chatState.userId} onSelected={props.onSelected} />
         ))}
       </FluentProvider>
     </FluentThemeProvider>

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -106,7 +106,7 @@ export const ChatListItem = ({ chat, myId, onSelected }: IMgtChatListItemProps &
         ? `${other?.displayName || (other as AadUserConversationMember)?.email || other?.id}`
         : `${me?.displayName} (You)`;
     }
-    return chatObj.topic || chatObj.chatType || chatObj.id;
+    return chatObj.topic || chatObj.id;
   };
 
   // Derives the timestamp to display
@@ -213,8 +213,8 @@ export const ChatListItem = ({ chat, myId, onSelected }: IMgtChatListItemProps &
       const provider = Providers.globalProvider;
       if (provider && provider.state === ProviderState.SignedIn) {
         const graph = provider.graph.forComponent('ChatListItem');
-        const load = async (id: string): Promise<Chat> => {
-          return await loadChatWithPreview(graph, id);
+        const load = (id: string): Promise<Chat> => {
+          return loadChatWithPreview(graph, id);
         };
         load(chatInternal.id).then(
           c => setChatInternal(c),

--- a/packages/mgt-chat/src/statefulClient/graph.chat.ts
+++ b/packages/mgt-chat/src/statefulClient/graph.chat.ts
@@ -45,6 +45,19 @@ export const loadChat = async (graph: IGraph, chatId: string): Promise<Chat> =>
     .get()) as Chat;
 
 /**
+ * Load the specified chat from graph with the members and last message expanded
+ *
+ * @param graph authenticated graph client from mgt
+ * @param chatId the id of the chat to load
+ * @returns {Promise<Chat>}
+ */
+export const loadChatWithPreview = async (graph: IGraph, chatId: string): Promise<Chat> =>
+  (await graph
+    .api(`/chats/${chatId}?$expand=members,lastMessagePreview`)
+    .middlewareOptions(prepScopes(...chatOperationScopes.loadChat))
+    .get()) as Chat;
+
+/**
  * Load the first page of messages from the specified chat
  * Will provide a nextLink to load more messages if there are more than the specified messageCount
  *


### PR DESCRIPTION
This PR allows for the chat prop sent to ChatListItem to only include the id (as shown below). If that is the case, the ChatListItem will load the other details it needs (title, membership, type, etc.).

```
<ChatListItem key={c.id} chat={{ id: c.id }} myId={chatState.userId} onSelected={props.onSelected} />
```

There are a few other changes as well:
- If there is no valid timestamp (for instance, it hasn't loaded yet), no error is displayed.
- If there is no valid title, the id is used so at least the user can disambiguate between chat threads.

The use of `chatInternal` is noteworthy. If we simply populated the chat details then the component does not re-render. Since chat isn't stored in state at all, passing a setState prop is also not appropriate. Therefore, the ChatListItem component itself creates a `chatInternal` object that is managed by state. It can be changed inside the component (for example, on loading) and it can be reset whenever the chat is changed externally.