### PR TITLE
Update loading chat threads to use last-read-timestamp

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -141,7 +141,7 @@ export const ChatList = ({
                   chat={c}
                   myId={chatListState.userId}
                   isSelected={c.id === selectedItem}
-                  isRead={false}
+                  isRead={c.id === selectedItem}
                 />
               </Button>
             ))}

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -171,17 +171,12 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IMgtChatListIte
           const lastUpdatedDateTime = new Date(c.lastUpdatedDateTime!);
           const lastMessagePreviewCreatedDateTime = new Date(c.lastMessagePreview?.createdDateTime as string);
           const lastReadTime = new Date(lastReadData.lastReadTime as string);
-          if (
+          const isRead = !(
             lastUpdatedDateTime > lastReadTime ||
             lastMessagePreviewCreatedDateTime > lastReadTime ||
             !lastReadData.lastReadTime
-          ) {
-            log('marking chat as unread: ', c.id);
-            setRead(false);
-          } else {
-            log('marking chat as read: ', c.id);
-            setRead(true);
-          }
+          );
+          setRead(isRead);
         }
       })
       .catch(e => error(e));

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -138,19 +138,21 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IMgtChatListIte
   // if chat changes, update the internal state to match
   useEffect(() => {
     setChatInternal(chat);
-    checkWhetherToMarkAsRead(chat);
+    if (isLoaded()) {
+      checkWhetherToMarkAsRead(chat);
+    }
   }, [chat]);
 
   // enrich the chat if necessary
   useEffect(() => {
-    if (chatInternal.id && (!chatInternal.chatType || !chatInternal.members)) {
+    if (isLoaded()) {
       const provider = Providers.globalProvider;
       if (provider && provider.state === ProviderState.SignedIn) {
         const graph = provider.graph.forComponent('ChatListItem');
         const load = (id: string): Promise<Chat> => {
           return loadChatWithPreview(graph, id);
         };
-        load(chatInternal.id).then(
+        load(chatInternal.id!).then(
           c => {
             setChatInternal(c);
             checkWhetherToMarkAsRead(c);
@@ -160,6 +162,10 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IMgtChatListIte
       }
     }
   }, [chatInternal]);
+
+  const isLoaded = () => {
+    return chatInternal.id && (!chatInternal.chatType || !chatInternal.members);
+  };
 
   // check whether to mark the chat as read or not
   const checkWhetherToMarkAsRead = (c: Chat) => {
@@ -171,7 +177,7 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IMgtChatListIte
         if (
           lastUpdatedDateTime > lastReadTime ||
           lastMessagePreviewCreatedDateTime > lastReadTime ||
-          lastReadData.lastReadTime === null
+          !lastReadData.lastReadTime
         ) {
           log('marking chat as unread: ', c.id);
           setRead(false);

--- a/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
+++ b/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
@@ -40,7 +40,7 @@ export class LastReadCache {
     if (lastReadTime instanceof Date) {
       lastReadTime = lastReadTime.toISOString();
     }
-    const data = { chatId, lastReadTime: lastReadTime };
+    const data = { chatId, lastReadTime };
     await this.cache.putValue(chatId, data);
     return data;
   }


### PR DESCRIPTION
Compares the two potentially latest timestamps in the chat object with the lastReadTimestamp stored in the cache. Depending on the comparison, marks the chatlistitem isRead state to either true or false.

Also I changed the default isRead prop to check if the item is currently selected. Not sure if this is the desired behavior, but it made sense to me that if the user has a chat thread open, it shouldn't appear as unread in the chatlist.

Testing:
The way I tested this change was to open a thread, wait for the `caching the last-read timestamp of now to chat ID` log, and then send messages on other threads, pushing that thread to position 4. Then refresh the page. The thread isn't loaded, so then click load more, and when it does load it appears as read. You could also send a message while its not loaded, and it will appear as unread.