### PR TITLE
fix timer cleanup

### DIFF
--- a/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
+++ b/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
@@ -40,7 +40,7 @@ export class LastReadCache {
     if (lastReadTime instanceof Date) {
       lastReadTime = lastReadTime.toISOString();
     }
-    const data = { chatId, lastReadTime: lastReadTime };
+    const data = { chatId, lastReadTime };
     await this.cache.putValue(chatId, data);
     return data;
   }


### PR DESCRIPTION
Timer cleanups for both user and chat are stored in the same index db. When cleanup routine fires in either one of the user or chat clients, it would cleanup subscriptions for both. The subscription type now carries a componentType property. When querying we can specify componentType as either chat or user. This is done via in-memory filtering. Given we don't expect a high number of subscriptions to be returned because we only return expired subscriptions based on a timestamp (maybe 100 or less?), this approach should be performant enough. 

There is an alternate design of using compound index, but it introduces complexity in the index/query. To keep it simple, I have opted for the in-memory filtering approach. 