### PR TITLE
add UI for banner showing disconnected state of the subscription

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -125,9 +125,16 @@ export const ChatList = ({
         if (state.status === 'chat threads loaded' && props.onLoaded) {
           props.onLoaded();
         }
+
+        if (state.status === 'server connection lost') {
+          // this happens when we have exhausted all retries to reconnect to the server
+          setHeaderBannerMessage('Oops! The connection was disrupted, please refresh.');
+        }
       });
       chatListClient.onChatListEvent(handleChatListEvent);
       return () => {
+        // log state of chatlistclient for debugging purposes
+        log(chatListClient.getState());
         chatListClient.offStateChange(setChatListState);
         chatListClient.offChatListEvent(handleChatListEvent);
         void chatListClient.tearDown();

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -61,6 +61,7 @@ export const ChatList = ({
   ...props
 }: MgtTemplateProps & IChatListItemProps & IChatListMenuItemsProps) => {
   const styles = useStyles();
+  const [headerBannerMessage, setHeaderBannerMessage] = useState<string>('');
   const [chatListClient, setChatListClient] = useState<StatefulGraphChatListClient | undefined>();
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
   const [menuItems, setMenuItems] = useState<ChatListMenuItem[]>(props.menuItems === undefined ? [] : props.menuItems);
@@ -106,6 +107,8 @@ export const ChatList = ({
   }, [selectedItem]);
 
   useEffect(() => {
+    setHeaderBannerMessage(''); // reset
+
     // handles events emitted from the chat list client
     const handleChatListEvent = (event: ChatListEvent) => {
       if (event.type === 'chatMessageReceived') {
@@ -126,6 +129,7 @@ export const ChatList = ({
         chatListClient.offStateChange(setChatListState);
         chatListClient.offChatListEvent(handleChatListEvent);
         void chatListClient.tearDown();
+        setHeaderBannerMessage('Oops! The connection was disrupted, please refresh.');
       };
     }
   }, [chatListClient]);
@@ -143,7 +147,11 @@ export const ChatList = ({
       <FluentProvider theme={webLightTheme}>
         <div>
           <div className={styles.headerContainer}>
-            <ChatListHeader buttonItems={chatListButtonItems} menuItems={menuItems} />
+            <ChatListHeader
+              bannerMessage={headerBannerMessage}
+              buttonItems={chatListButtonItems}
+              menuItems={menuItems}
+            />
           </div>
           <div>
             {chatListState?.chatThreads.map(c => (

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -109,8 +109,6 @@ export const ChatList = ({
   }, [selectedChatId]);
 
   useEffect(() => {
-    setHeaderBannerMessage(''); // reset
-
     // handles events emitted from the chat list client
     const handleChatListEvent = (event: ChatListEvent) => {
       if (event.type === 'chatMessageReceived') {
@@ -124,6 +122,14 @@ export const ChatList = ({
       chatListClient.onStateChange(state => {
         if (state.status === 'chat threads loaded' && props.onLoaded) {
           props.onLoaded();
+        }
+
+        if (state.status === 'server connection established') {
+          setHeaderBannerMessage(''); // reset
+        }
+
+        if (state.status === 'creating server connections') {
+          setHeaderBannerMessage('Connecting...');
         }
 
         if (state.status === 'server connection lost') {

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -143,7 +143,7 @@ export const ChatList = ({
         log(chatListClient.getState());
         chatListClient.offStateChange(setChatListState);
         chatListClient.offChatListEvent(handleChatListEvent);
-        void chatListClient.tearDown();
+        chatListClient.tearDown();
         setHeaderBannerMessage('We ran into a problem. Reconnecting...');
       };
     }

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -133,7 +133,9 @@ export const ChatList = ({
         }
 
         if (state.status === 'server connection lost') {
-          // this happens when we have exhausted all retries to reconnect to the server
+          // this happens when
+          // a) we lost connection to the server and we will try to reconnect OR
+          // b) we have exhausted all retries to reconnect to the server
           setHeaderBannerMessage('Oops! The connection was disrupted, please refresh.');
         }
       });

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -133,10 +133,8 @@ export const ChatList = ({
         }
 
         if (state.status === 'server connection lost') {
-          // this happens when
-          // a) we lost connection to the server and we will try to reconnect OR
-          // b) we have exhausted all retries to reconnect to the server
-          setHeaderBannerMessage('Oops! The connection was disrupted, please refresh.');
+          // this happens when we lost connection to the server and we will try to reconnect
+          setHeaderBannerMessage('We ran into a problem. Reconnecting...');
         }
       });
       chatListClient.onChatListEvent(handleChatListEvent);
@@ -146,7 +144,7 @@ export const ChatList = ({
         chatListClient.offStateChange(setChatListState);
         chatListClient.offChatListEvent(handleChatListEvent);
         void chatListClient.tearDown();
-        setHeaderBannerMessage('Oops! The connection was disrupted, please refresh.');
+        setHeaderBannerMessage('We ran into a problem. Reconnecting...');
       };
     }
   }, [chatListClient]);

--- a/packages/mgt-chat/src/components/ChatListHeader/ChatListHeader.tsx
+++ b/packages/mgt-chat/src/components/ChatListHeader/ChatListHeader.tsx
@@ -7,11 +7,13 @@ import { Circle } from '../Circle/Circle';
 
 const useStyles = makeStyles({
   headerContainer: {
+    width: '100%'
+  },
+  controlsContainer: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between', // This distributes the space evenly
-    alignItems: 'center',
-    width: '100%'
+    alignItems: 'center'
   },
   buttonIcon: {
     flexGrow: 0,
@@ -31,6 +33,15 @@ const useStyles = makeStyles({
     '&:hover': {
       backgroundColor: 'transparent'
     }
+  },
+  bannerClassName: {
+    backgroundColor: '#FFE1A7',
+    textAlign: 'center',
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+    paddingTop: '5px',
+    paddingBottom: '5px',
+    marginBottom: '5px'
   }
 });
 
@@ -39,6 +50,8 @@ export const ChatListHeader = (
   props: MgtTemplateProps &
     IChatListMenuItemsProps & {
       buttonItems?: ChatListButtonItem[];
+      bannerMessage?: string;
+      bannerClassName?: string;
     }
 ) => {
   const classes = useStyles();
@@ -46,20 +59,25 @@ export const ChatListHeader = (
   const buttonItems: ChatListButtonItem[] = props.buttonItems === undefined ? [] : props.buttonItems;
   return (
     <div className={classes.headerContainer}>
-      <div>
-        {buttonItems.map((buttonItem, index) => (
-          <Button key={index} className={classes.button} onClick={buttonItem.onClick}>
-            <div className={classes.buttonIcon}>
-              <Circle>{buttonItem.renderIcon()}</Circle>
-            </div>
-          </Button>
-        ))}
-      </div>
-      <div>
-        <Login showPresence={true} loginView="avatar" />
-      </div>
-      <div>
-        <EllipsisMenu menuItems={props.menuItems} />
+      {props.bannerMessage && props.bannerMessage !== '' && (
+        <div className={classes.bannerClassName}>{props.bannerMessage}</div>
+      )}
+      <div className={classes.controlsContainer}>
+        <div>
+          {buttonItems.map((buttonItem, index) => (
+            <Button key={index} className={classes.button} onClick={buttonItem.onClick}>
+              <div className={classes.buttonIcon}>
+                <Circle>{buttonItem.renderIcon()}</Circle>
+              </div>
+            </Button>
+          ))}
+        </div>
+        <div>
+          <Login showPresence={true} loginView="avatar" />
+        </div>
+        <div>
+          <EllipsisMenu menuItems={props.menuItems} />
+        </div>
       </div>
     </div>
   );

--- a/packages/mgt-chat/src/components/ChatListHeader/ChatListHeader.tsx
+++ b/packages/mgt-chat/src/components/ChatListHeader/ChatListHeader.tsx
@@ -50,8 +50,7 @@ export const ChatListHeader = (
   props: MgtTemplateProps &
     IChatListMenuItemsProps & {
       buttonItems?: ChatListButtonItem[];
-      bannerMessage?: string;
-      bannerClassName?: string;
+      bannerMessage: string;
     }
 ) => {
   const classes = useStyles();
@@ -59,9 +58,7 @@ export const ChatListHeader = (
   const buttonItems: ChatListButtonItem[] = props.buttonItems === undefined ? [] : props.buttonItems;
   return (
     <div className={classes.headerContainer}>
-      {props.bannerMessage && props.bannerMessage !== '' && (
-        <div className={classes.bannerClassName}>{props.bannerMessage}</div>
-      )}
+      {props.bannerMessage !== '' && <div className={classes.bannerClassName}>{props.bannerMessage}</div>}
       <div className={classes.controlsContainer}>
         <div>
           {buttonItems.map((buttonItem, index) => (

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -232,9 +232,6 @@ export class GraphNotificationUserClient {
       if (subscriptions.length === 0) {
         log('No subscriptions found in session state. Creating a new subscription.');
 
-        // no reason to keep a connection if there are no subscriptions,
-        await this.closeSignalRConnection();
-
         await this.subscribeToResource(this.currentUserId, `/users/${this.currentUserId}/chats/getAllmessages`, [
           'created',
           'updated',

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -21,7 +21,7 @@ import { Timer } from '../utils/Timer';
 export const appSettings = {
   defaultSubscriptionLifetimeInMinutes: 10,
   renewalThreshold: 75, // The number of seconds before subscription expires it will be renewed
-  renewalTimerInterval: 20, // The number of seconds between executions of the renewal timer
+  renewalTimerInterval: 10, // The number of seconds between executions of the renewal timer
   useCanary: GraphConfig.useCanary
 };
 

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -220,42 +220,41 @@ export class GraphNotificationUserClient {
       } catch (e) {
         error(e);
       }
-      return;
-    }
+    } else {
+      for (const subscription of subscriptions) {
+        if (!subscription.expirationDateTime || !subscription.id || !subscription.notificationUrl) continue;
 
-    for (const subscription of subscriptions) {
-      if (!subscription.expirationDateTime || !subscription.id || !subscription.notificationUrl) continue;
+        const expirationTime = new Date(subscription.expirationDateTime);
+        const now = new Date();
+        const diff = Math.round((expirationTime.getTime() - now.getTime()) / 1000);
 
-      const expirationTime = new Date(subscription.expirationDateTime);
-      const now = new Date();
-      const diff = Math.round((expirationTime.getTime() - now.getTime()) / 1000);
+        if (diff <= appSettings.renewalThreshold) {
+          this.renewalCount++;
+          log(`Renewing Graph subscription. RenewalCount: ${this.renewalCount}.`);
 
-      if (diff <= appSettings.renewalThreshold) {
-        this.renewalCount++;
-        log(`Renewing Graph subscription. RenewalCount: ${this.renewalCount}.`);
+          const newExpirationTime = new Date(
+            new Date().getTime() + appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
+          );
 
-        const newExpirationTime = new Date(
-          new Date().getTime() + appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
-        );
-
-        try {
-          await this.renewSubscription(subscription.id, newExpirationTime.toISOString());
-        } catch (e) {
-          error(e);
-          // this error indicates we are not able to successfully renew the subscription, so we should create a new one.
-          if ((e as { statusCode?: number }).statusCode === 404) {
-            log('Removing subscription from cache', subscription.id);
-            await this.subscriptionCache.deleteCachedSubscriptions(this.userId, this.sessionId);
-            await this.subscribeToUserNotifications(this.userId);
+          try {
+            await this.renewSubscription(subscription.id, newExpirationTime.toISOString());
+          } catch (e) {
+            error(e);
+            // this error indicates we are not able to successfully renew the subscription, so we should create a new one.
+            if ((e as { statusCode?: number }).statusCode === 404) {
+              log('Removing subscription from cache', subscription.id);
+              await this.subscriptionCache.deleteCachedSubscriptions(this.userId, this.sessionId);
+              await this.subscribeToUserNotifications(this.userId);
+            }
           }
+        } else {
+          // create a connection to the web socket if one does not exist
+          if (!this.connection) await this.createSignalRConnection(subscription.notificationUrl);
         }
-      } else {
-        // create a connection to the web socket if one does not exist
-        if (!this.connection) await this.createSignalRConnection(subscription.notificationUrl);
-      }
 
-      // Expecting only one subscription per user
-      break;
+        // Expecting only one subscription per user
+        break;
+      }
     }
 
     this.renewalInterval = this.timer.setTimeout(this.renewalSync, appSettings.renewalTimerInterval * 1000);

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -50,6 +50,7 @@ export class GraphNotificationUserClient {
   private connection?: HubConnection = undefined;
   private renewalInterval?: string;
   private renewalCount = 0;
+  private isRewnewalInProgress = false;
   private userId = '';
   private get sessionId() {
     return 'default';
@@ -210,6 +211,13 @@ export class GraphNotificationUserClient {
   };
 
   private readonly renewal = async () => {
+    if (this.isRewnewalInProgress) {
+      log('Renewal already in progress');
+      return;
+    }
+
+    this.isRewnewalInProgress = true;
+
     const subscriptions =
       (await this.subscriptionCache.loadSubscriptions(this.userId, this.sessionId))?.subscriptions || [];
     if (subscriptions.length === 0) {
@@ -257,6 +265,7 @@ export class GraphNotificationUserClient {
       }
     }
 
+    this.isRewnewalInProgress = false;
     this.renewalInterval = this.timer.setTimeout(this.renewalSync, appSettings.renewalTimerInterval * 1000);
   };
 

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -83,11 +83,10 @@ export class GraphNotificationUserClient {
    * Call this method when the component that depends an instance of this class is being removed from the DOM
    * i.e
    */
-  public async tearDown() {
+  public tearDown() {
     log('cleaning up user graph notification resources');
     if (this.renewalInterval) this.timer.clearInterval(this.renewalInterval);
     this.timer.close();
-    await this.unsubscribeFromUserNotifications(this.userId);
   }
 
   private readonly getToken = async () => {

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -266,6 +266,7 @@ export class GraphNotificationUserClient {
     }
 
     this.isRewnewalInProgress = false;
+    log('Starting timer for renewal');
     this.renewalInterval = this.timer.setTimeout(this.renewalSync, appSettings.renewalTimerInterval * 1000);
   };
 

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -232,6 +232,9 @@ export class GraphNotificationUserClient {
       if (subscriptions.length === 0) {
         log('No subscriptions found in session state. Creating a new subscription.');
 
+        // no reason to keep a connection if there are no subscriptions,
+        await this.closeSignalRConnection();
+
         await this.subscribeToResource(this.currentUserId, `/users/${this.currentUserId}/chats/getAllmessages`, [
           'created',
           'updated',

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -60,6 +60,7 @@ export type GraphChatListClient = Pick<MessageThreadProps, 'userId'> & {
   status:
     | 'initial'
     | 'creating server connections'
+    | 'server connection lost'
     | 'subscribing to notifications'
     | 'loading messages'
     | 'no session id'
@@ -585,6 +586,11 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     this._eventEmitter.on('chatMessageReceived', (message: ChatMessage) => void this.onMessageReceived(message));
     this._eventEmitter.on('chatMessageDeleted', this.onMessageDeleted);
     this._eventEmitter.on('chatMessageEdited', (message: ChatMessage) => void this.onMessageEdited(message));
+    this._eventEmitter.on('disconnected', () => {
+      this.notifyStateChange((draft: GraphChatListClient) => {
+        draft.status = 'server connection lost';
+      });
+    });
   }
 }
 

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -61,6 +61,7 @@ export type GraphChatListClient = Pick<MessageThreadProps, 'userId'> & {
     | 'initial'
     | 'creating server connections'
     | 'server connection lost'
+    | 'server connection established'
     | 'subscribing to notifications'
     | 'loading messages'
     | 'no session id'
@@ -565,7 +566,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
         tasks.push(this._notificationClient.subscribeToUserNotifications(this._userId, this.sessionId));
         await Promise.all(tasks);
       } catch (e) {
-        console.error('Failed to load chat data or subscribe to notications: ', e);
+        error('Failed to load chat data or subscribe to notications: ', e);
         if (e instanceof GraphError) {
           this.notifyStateChange((draft: GraphChatListClient) => {
             draft.status = 'no messages';
@@ -589,6 +590,11 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     this._eventEmitter.on('disconnected', () => {
       this.notifyStateChange((draft: GraphChatListClient) => {
         draft.status = 'server connection lost';
+      });
+    });
+    this._eventEmitter.on('connected', () => {
+      this.notifyStateChange((draft: GraphChatListClient) => {
+        draft.status = 'server connection established';
       });
     });
   }

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -166,8 +166,8 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   /**
    * Provides a method to clean up any resources being used internally when a consuming component is being removed from the DOM
    */
-  public async tearDown() {
-    await this._notificationClient.tearDown();
+  public tearDown() {
+    this._notificationClient.tearDown();
   }
 
   /**

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -149,7 +149,6 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     Providers.globalProvider.onActiveAccountChanged(this.onActiveAccountChanged);
     this._eventEmitter = new ThreadEventEmitter();
     this.registerEventListeners();
-    // this._cache = new MessageCache();
     this._graph = graph('mgt-chat', GraphConfig.version);
     this.chatThreadsPerPage = chatThreadsPerPage;
     this._notificationClient = new GraphNotificationUserClient(this._eventEmitter, this._graph);

--- a/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
+++ b/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
@@ -22,6 +22,7 @@ export type ChatEvent =
   | 'chatThreadPropertiesUpdated'
   | 'participantAdded'
   | 'participantRemoved'
+  | 'disconnected'
   | 'notificationsSubscribedForResource';
 
 export class ThreadEventEmitter {
@@ -64,5 +65,8 @@ export class ThreadEventEmitter {
   }
   notificationsSubscribedForResource(resouce: string) {
     this.emitter.emit('notificationsSubscribedForResource', resouce);
+  }
+  disconnected() {
+    this.emitter.emit('disconnected');
   }
 }

--- a/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
+++ b/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
@@ -23,6 +23,7 @@ export type ChatEvent =
   | 'participantAdded'
   | 'participantRemoved'
   | 'disconnected'
+  | 'connected'
   | 'notificationsSubscribedForResource';
 
 export class ThreadEventEmitter {
@@ -68,5 +69,8 @@ export class ThreadEventEmitter {
   }
   disconnected() {
     this.emitter.emit('disconnected');
+  }
+  connected() {
+    this.emitter.emit('connected');
   }
 }


### PR DESCRIPTION
The following changes:

1. Added event handlers for connection and disconnects and users are notified if we are disconnected.
2. Retry up to 10 times with back off in ms as the following `0, 2000, 10000, 30000, 45000, 60000, 90000, 120000, 180000, 240000`
3. Remove cleanup timer. 
4. We are still checking every 20 seconds to ensure subscriptions are valid. If we need to renew and get a 404, then we are removing the subscription from cache and creating a new subscription. 
5. Remove spammy logging for checking every 20 seconds. When we actually execute the renewal, we are logging that.
6. I noticed that renewal process is stacked a few times, so I added a guard to prevent it from firing if a renewal http request is already in progress.