### PR TITLE
fix emoji build error

### DIFF
--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -8,10 +8,10 @@ import {
   TeamworkApplicationIdentity,
   TeamsAppInstallation
 } from '@microsoft/microsoft-graph-types';
-import { Person, PersonCardInteraction, log } from '@microsoft/mgt-react';
+import { Person, PersonCardInteraction } from '@microsoft/mgt-react';
 import { ProviderState, Providers, error } from '@microsoft/mgt-element';
 import { ChatListItemIcon } from '../ChatListItemIcon/ChatListItemIcon';
-import { rewriteEmojiContent } from '../../utils/rewriteEmojiContent';
+import { rewriteEmojiContentToText } from '../../utils/rewriteEmojiContent';
 import { convert } from 'html-to-text';
 import { loadChatWithPreview, loadAppsInChat } from '../../statefulClient/graph.chat';
 import { DefaultProfileIcon } from './DefaultProfileIcon';
@@ -455,7 +455,7 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IMgtChatListIte
       }
 
       // convert html to text
-      content = rewriteEmojiContent(content);
+      content = rewriteEmojiContentToText(content);
       content = convert(content);
     }
 

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -218,11 +218,6 @@ export class GraphNotificationUserClient {
 
     this.isRewnewalInProgress = true;
 
-    if (this.currentUserId !== '' && this.currentUserId !== this.userId) {
-      log('User has changed. Unsubscribing from previous user');
-      await this.unsubscribeFromUserNotifications(this.currentUserId);
-    }
-
     this.currentUserId = this.userId;
 
     try {
@@ -348,6 +343,7 @@ export class GraphNotificationUserClient {
   private async deleteSubscription(id: string) {
     try {
       await this.graph.api(`${GraphConfig.subscriptionEndpoint}/${id}`).delete();
+      log(`Deleted subscription with id: ${id}`);
     } catch (e) {
       error(e);
     }
@@ -369,7 +365,11 @@ export class GraphNotificationUserClient {
     this.connection = undefined;
   }
 
-  private async unsubscribeFromUserNotifications(userId: string) {
+  public async unsubscribeFromUserNotifications(userId: string) {
+    if (this.renewalInterval) {
+      this.timer.clearTimeout(this.renewalInterval);
+    }
+
     await this.closeSignalRConnection();
     const cacheData = await this.subscriptionCache.loadSubscriptions(userId, this.sessionId);
     if (cacheData) {

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -106,7 +106,7 @@ export class GraphNotificationUserClient {
     if (typeof message !== 'string') throw new Error('Expected string from receivenotificationmessageasync');
 
     const notification: ReceivedNotification = JSON.parse(message) as ReceivedNotification;
-    log('received notification message', notification);
+    log('received user notification message', notification);
     const emitter: ThreadEventEmitter | undefined = this.emitter;
     if (!notification.resourceData) throw new Error('Message did not contain resourceData');
     if (isMessageNotification(notification)) {

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -256,6 +256,9 @@ export class GraphNotificationUserClient {
                 log('Removing subscription from cache', subscription.id);
                 await this.subscriptionCache.deleteCachedSubscriptions(this.currentUserId, this.sessionId);
                 await this.subscribeToUserNotifications(this.currentUserId);
+
+                const emitter: ThreadEventEmitter | undefined = this.emitter;
+                emitter?.reconnected();
               }
             }
           } else {

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -621,6 +621,9 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
         draft.status = 'server connection established';
       });
     });
+    this._eventEmitter.on('reconnected', () => {
+      this.loadAndAppendChatThreads('', [], this.chatThreadsPerPage);
+    });
   }
 }
 

--- a/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
+++ b/packages/mgt-chat/src/statefulClient/ThreadEventEmitter.ts
@@ -24,6 +24,7 @@ export type ChatEvent =
   | 'participantRemoved'
   | 'disconnected'
   | 'connected'
+  | 'reconnected'
   | 'notificationsSubscribedForResource';
 
 export class ThreadEventEmitter {
@@ -72,5 +73,8 @@ export class ThreadEventEmitter {
   }
   connected() {
     this.emitter.emit('connected');
+  }
+  reconnected() {
+    this.emitter.emit('reconnected');
   }
 }

--- a/packages/mgt-chat/src/utils/rewriteEmojiContent.tests.ts
+++ b/packages/mgt-chat/src/utils/rewriteEmojiContent.tests.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from '@open-wc/testing';
-import { rewriteEmojiContentToHTML } from './rewriteEmojiContent';
+import { rewriteEmojiContentToHTML, rewriteEmojiContentToText } from './rewriteEmojiContent';
 
 describe('rewrite emoji to standard HTML', () => {
   it('rewrites an emoji correctly', async () => {
@@ -36,5 +36,26 @@ describe('rewrite emoji to standard HTML', () => {
     await expect(result).to.be.equal(
       `<p><span contenteditable="false" title="Heart eyes" type="(hearteyes)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="hearteyes" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/hearteyes/default/20_f.png" title="Heart eyes" alt="😍" style="width:20px;height:20px;"></span></p><p><span contenteditable="false" title="Zany face" type="(1f92a_zanyface)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="1f92a_zanyface" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/1f92a_zanyface/default/20_f.png" title="Zany face" alt="🤪" style="width:20px;height:20px;"></span></p><p><span contenteditable="false" title="Cool" type="(cool)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/20_f.png" title="Cool" alt="😎" style="width:20px;height:20px;"></span></p>`
     );
+  });
+});
+
+describe('emoji rewrite tests to Text', () => {
+  it('rewrites an emoji correctly', async () => {
+    const result = rewriteEmojiContentToText(`<emoji id="cool" alt="😎" title="Cool"></emoji>`);
+    await expect(result).to.be.equal('😎');
+  });
+  it('rewrites an emoji in a p tag correctly', async () => {
+    const result = rewriteEmojiContentToText(`<p><emoji id="cool" alt="😎" title="Cool"></emoji></p>`);
+    await expect(result).to.be.equal('<p>😎</p>');
+  });
+  it('rewrites multiple emoji in a p correctly', async () => {
+    const result = rewriteEmojiContentToText(
+      `<p><emoji id="cool" alt="😎" title="Cool"></emoji><emoji id="1f92a_zanyface" alt="🤪" title="Zany face"></emoji></p>`
+    );
+    await expect(result).to.be.equal('<p>😎🤪</p>');
+  });
+  it('returns the original value if there is no emoji', async () => {
+    const result = rewriteEmojiContentToText('<p><em>Seb is cool</em></p>');
+    await expect(result).to.be.equal('<p><em>Seb is cool</em></p>');
   });
 });

--- a/packages/mgt-chat/src/utils/rewriteEmojiContent.ts
+++ b/packages/mgt-chat/src/utils/rewriteEmojiContent.ts
@@ -48,6 +48,7 @@ export const rewriteEmojiContentToHTML = (content: string): string => {
     img.setAttribute('itemscope', '');
     img.setAttribute('itemtype', 'http://schema.skype.com/Emoji');
     img.setAttribute('itemid', id);
+
     img.setAttribute(
       'src',
       `https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/${id}/default/${size}_f.png`
@@ -61,3 +62,36 @@ export const rewriteEmojiContentToHTML = (content: string): string => {
   }
   return dom.body.innerHTML;
 };
+
+/**
+ * Regex to detect and extract emoji alt text
+ *
+ * Pattern breakdown:
+ * (<emoji[^>]+): Captures the opening emoji tag, including any attributes.
+ * alt=["'](\w*[^"']*)["']: Matches and captures the "alt" attribute value within single or double quotes. The value can contain word characters but not quotes.
+ * (.[^>]): Captures any remaining text within the opening emoji tag, excluding the closing angle bracket.
+ * ><\/emoji>: Matches the remaining part of the tag.
+ */
+const emojiRegex = /(<emoji[^>]+)alt=["'](\w*[^"']*)["'](.[^>]+)><\/emoji>/;
+const emojiMatch = (messageContent: string): RegExpMatchArray | null => {
+  return messageContent.match(emojiRegex);
+};
+// iterative repave the emoji custom element with the content of the alt attribute
+// on the emoji element
+const processEmojiContent = (messageContent: string): string => {
+  let result = messageContent;
+  let match = emojiMatch(result);
+  while (match) {
+    result = result.replace(emojiRegex, '$2');
+    match = emojiMatch(result);
+  }
+  return result;
+};
+
+/**
+ * if the content contains an <emoji> tag with an alt attribute the content is replaced by replacing the emoji tags with the content of their alt attribute.
+ * @param {string} content
+ * @returns {string} the content with any emoji tags replaced by the content of their alt attribute.
+ */
+export const rewriteEmojiContentToText = (content: string): string =>
+  emojiMatch(content) ? processEmojiContent(content) : content;


### PR DESCRIPTION
the method for performing regex based emoji replacement was removed, I restored and renamed the method. all previous unit tests were also restored.

this is also fix for When subscription expires, we will need to create a new subscription and also reload chat threads