### PR TITLE
Bug fixes to support ChatListPage

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -155,7 +155,7 @@ export const ChatList = ({
       chatListClient.tearDown();
       setHeaderBannerMessage('We ran into a problem. Please close or refresh.');
     };
-  }, [chatListClient, onMessageReceived, onAllMessagesRead, onLoaded]); // menuItems
+  }, [chatListClient, onMessageReceived, onAllMessagesRead, onLoaded]);
 
   const markThreadAsRead = (chatThread: string) => {
     const markedChatThreads = chatListClient?.markChatThreadsAsRead([chatThread]);

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -155,7 +155,7 @@ export const ChatList = ({
       chatListClient.tearDown();
       setHeaderBannerMessage('We ran into a problem. Please close or refresh.');
     };
-  }, [chatListClient, onMessageReceived, onAllMessagesRead, onLoaded]);
+  }, [chatListClient, onMessageReceived, onLoaded]);
 
   const markThreadAsRead = (chatThread: string) => {
     const markedChatThreads = chatListClient?.markChatThreadsAsRead([chatThread]);

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -430,6 +430,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
         // update the last message preview and bring to the top
         chatThread.lastMessagePreview = event.message as ChatMessageInfo;
         chatThread.lastUpdatedDateTime = event.message.lastModifiedDateTime;
+        chatThread.isRead = false;
         bringToTop();
       } else if (event.type === 'chatMessageReceived' && event.message?.chatId) {
         // create a new chat thread at the top

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useState } from 'react';
 import './App.css';
 import { Login } from '@microsoft/mgt-react';
 import { Chat, ChatList, NewChat, ChatListButtonItem, ChatListMenuItem } from '@microsoft/mgt-chat';
-import { Chat as GraphChat } from '@microsoft/microsoft-graph-types';
+import { ChatMessage, Chat as GraphChat } from '@microsoft/microsoft-graph-types';
 import { ChatAdd24Filled, ChatAdd24Regular, bundleIcon } from '@fluentui/react-icons';
 
 const ChatAddIconBundle = bundleIcon(ChatAdd24Filled, ChatAdd24Regular);
@@ -12,7 +12,7 @@ export const ChatAddIcon = (): JSX.Element => {
   return <ChatAddIconBundle color={iconColor} />;
 };
 
-const ChatListWrapper = memo(({ onSelected, selectedChatId }: { onSelected: (e: GraphChat) => void, selectedChatId?: string }) => {
+const ChatListWrapper = memo(({ onSelected }: { onSelected: (e: GraphChat) => void }) => {
   const buttons: ChatListButtonItem[] = [
     {
       renderIcon: () => <ChatAddIcon />,
@@ -31,8 +31,8 @@ const ChatListWrapper = memo(({ onSelected, selectedChatId }: { onSelected: (e: 
   const onLoaded = () => {
     console.log('Chat threads loaded.');
   };
-  const onMessageReceived = () => {
-    console.log('SampleChatLog: Message received');
+  const onMessageReceived = (msg: ChatMessage) => {
+    console.log('SampleChatLog: Message received', msg);
   };
 
   return (
@@ -42,7 +42,6 @@ const ChatListWrapper = memo(({ onSelected, selectedChatId }: { onSelected: (e: 
       menuItems={menus}
       buttonItems={buttons}
       onSelected={onSelected}
-      selectedChatId={selectedChatId}
       onMessageReceived={onMessageReceived}
       onAllMessagesRead={onAllMessagesRead}
     />
@@ -50,8 +49,6 @@ const ChatListWrapper = memo(({ onSelected, selectedChatId }: { onSelected: (e: 
 });
 
 function App() {
-  // Copied from the sample ChatItem.tsx
-  // This should probably move up to ChatList.tsx so that all the ChatListItems can share myId
   const [chatId, setChatId] = useState<string>('');
   const [showNewChat, setShowNewChat] = useState<boolean>(false);
 
@@ -73,7 +70,7 @@ function App() {
       </header>
       <main className="main">
         <div className="chat-selector">
-          <ChatListWrapper onSelected={chatSelected} selectedChatId={chatId} />
+          <ChatListWrapper onSelected={chatSelected} />
           <br />
           <button onClick={() => setChatId('')}>Clear selected chat</button>
           <br />


### PR DESCRIPTION
This PR addresses the following issues:
* eslint was reporting that dependencies were not being tracked by several useEffect methods that rely on those properties - this has been fixed.
* onMessageReceived() should have been sending the message payload. This is required in some cases to manage a notification panel.
* A user selecting a new chat thread (as opposed to the App) was causing the entire component to re-render which also caused some issues with state changes. The App changing the selected thread will still cause a full re-render but this shouldn't happen often.
* MarkAllThreads is now implemented without causing a state change.