### PR TITLE
BUG 452: Chat doesn't always show the "no chats selected" error indicators

### DIFF
--- a/packages/mgt-chat/src/components/Chat/Chat.tsx
+++ b/packages/mgt-chat/src/components/Chat/Chat.tsx
@@ -2,7 +2,7 @@ import { FluentThemeProvider, MessageThread, SendBox, MessageThreadStyles } from
 import { FluentTheme } from '@fluentui/react';
 import { FluentProvider, makeStyles, shorthands, webLightTheme } from '@fluentui/react-components';
 import { Person, PersonCardInteraction, Spinner } from '@microsoft/mgt-react';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { StatefulGraphChatClient } from '../../statefulClient/StatefulGraphChatClient';
 import { useGraphChatClient } from '../../statefulClient/useGraphChatClient';
 import { onRenderMessage } from '../../utils/chat';
@@ -107,18 +107,20 @@ const messageThreadStyles: MessageThreadStyles = {
 
 export const Chat = ({ chatId }: IMgtChatProps) => {
   const styles = useStyles();
-  const chatClient: StatefulGraphChatClient = useGraphChatClient(chatId);
-  const [chatState, setChatState] = useState(chatClient.getState());
-  useEffect(() => {
+  const chatClient: StatefulGraphChatClient = useGraphChatClient(chatId, () => {
     chatClient.onStateChange(setChatState);
     return () => {
       chatClient.offStateChange(setChatState);
     };
-  }, [chatClient]);
+  });
+  const [chatState, setChatState] = useState(chatClient.getState());
 
-  const isLoading = ['creating server connections', 'subscribing to notifications', 'loading messages'].includes(
-    chatState.status
-  );
+  const isLoading = [
+    'initial',
+    'creating server connections',
+    'subscribing to notifications',
+    'loading messages'
+  ].includes(chatState.status);
 
   const disabled = !chatId || !!chatState.activeErrorMessages.length;
   const placeholderText = disabled ? 'You cannot send a message' : 'Type a message...';
@@ -128,7 +130,6 @@ export const Chat = ({ chatId }: IMgtChatProps) => {
       <FluentProvider id="fluentui" theme={webLightTheme} className={styles.fullHeight}>
         <div className={styles.chat}>
           <ChatHeader chatState={chatState} />
-          {<div>CHAT: {chatState.status}</div>}
           {chatState.userId && chatId && chatState.messages.length > 0 ? (
             <>
               <div className={styles.chatMessages}>

--- a/packages/mgt-chat/src/statefulClient/useGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/useGraphChatClient.ts
@@ -44,22 +44,30 @@ const useSessionId = (): string => {
 /**
  * Custom hook to abstract the creation of a stateful graph chat client.
  * @param {string} chatId the current chatId to be rendered
+ * @param {React.EffectCallback} pre an optional useEffect function to be run before other useEffects
+ * @param {React.EffectCallback} post an optional useEffect function to be run after other useEffects
  * @returns {StatefulGraphChatClient} a stateful graph chat client that is subscribed to the given chatId
  */
-export const useGraphChatClient = (chatId: string): StatefulGraphChatClient => {
+export const useGraphChatClient = (
+  chatId: string,
+  pre: React.EffectCallback | undefined = undefined,
+  post: React.EffectCallback | undefined = undefined
+): StatefulGraphChatClient => {
   const sessionId = useSessionId();
   const [chatClient] = useState<StatefulGraphChatClient>(() => new StatefulGraphChatClient());
+
+  // pre
+  // NOTE: we need the registration of state handlers before changing state
+  useEffect(() => {
+    if (pre) pre();
+  }, [chatClient, pre]);
 
   // when chatId or sessionId changes this effect subscribes or unsubscribes
   // the component to/from web socket based notifications for the given chatId
   useEffect(() => {
     // we must have both a chatId & sessionId to subscribe.
-    log(`chat Id ${chatId}, sessionId ${sessionId}`);
     if (chatId && sessionId) chatClient.subscribeToChat(chatId, sessionId);
-    else {
-      log('set status');
-      chatClient.setStatus('no chat id');
-    }
+    else chatClient.setStatus('no chat id');
   }, [chatId, sessionId, chatClient]);
 
   // Returns a cleanup function to call tearDown on the chatClient
@@ -70,6 +78,11 @@ export const useGraphChatClient = (chatId: string): StatefulGraphChatClient => {
       void chatClient.tearDown();
     };
   }, [chatClient]);
+
+  // post
+  useEffect(() => {
+    if (post) post();
+  }, [chatClient, post]);
 
   return chatClient;
 };


### PR DESCRIPTION
If no chat ID is selected, then there is supposed to be an error message and icon present. This was not showing up because the state change for `no 