### PR TITLE
BUG 450: Messages for chats that are not loaded would cause an exception

### DIFF
--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -346,9 +346,10 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     this.notifyStateChange((draft: GraphChatListClient) => {
       // find the chat thread
       const chatThreadIndex = draft.chatThreads.findIndex(c => c.id === event.message.chatId);
-      const chatThread = draft.chatThreads[chatThreadIndex];
+      const chatThread: GraphChatThread | undefined = draft.chatThreads[chatThreadIndex];
 
       if (
+        chatThread &&
         event.message.lastModifiedDateTime &&
         chatThread.lastMessagePreview?.createdDateTime &&
         event.message.lastModifiedDateTime < chatThread.lastMessagePreview.createdDateTime


### PR DESCRIPTION
`chatThread` could be undefined because the incoming message is for a chat that isn't loaded. Therefore, there needs to be a null check.

The way this event system works, there is no callstack that points back to where this issue was, so it required line by line in the debugger to find the issue.