### PR TITLE
BUG 446: write previously unhandled messages related to wake-up to the log

### DIFF
--- a/packages/mgt-chat/src/statefulClient/GraphNotificationClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationClient.ts
@@ -91,7 +91,9 @@ export class GraphNotificationClient {
     if (this.cleanupTimeout) this.timer.clearTimeout(this.cleanupTimeout);
     if (this.renewalTimeout) this.timer.clearTimeout(this.renewalTimeout);
     this.timer.close();
-    await this.unsubscribeFromChatNotifications(this.chatId, this.sessionId);
+    if (this.chatId && this.sessionId) {
+      await this.unsubscribeFromChatNotifications(this.chatId, this.sessionId);
+    }
   }
 
   private readonly getToken = async () => {
@@ -183,38 +185,43 @@ export class GraphNotificationClient {
     if (this.renewalTimeout === undefined) this.startRenewalTimer();
   };
 
-  private async subscribeToResource(resourcePath: string, changeTypes: ChangeTypes[]) {
-    // build subscription request
-    const expirationDateTime = new Date(
-      new Date().getTime() + appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
-    ).toISOString();
-    const subscriptionDefinition: Subscription = {
-      changeType: changeTypes.join(','),
-      notificationUrl: `${GraphConfig.webSocketsPrefix}?groupId=${this.chatId}&sessionId=${this.sessionId}`,
-      resource: resourcePath,
-      expirationDateTime,
-      includeResourceData: true,
-      clientState: 'wsssecret'
-    };
+  private async subscribeToResource(resourcePath: string, changeTypes: ChangeTypes[]): Promise<void[]> {
+    try {
+      // build subscription request
+      const expirationDateTime = new Date(
+        new Date().getTime() + appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
+      ).toISOString();
+      const subscriptionDefinition: Subscription = {
+        changeType: changeTypes.join(','),
+        notificationUrl: `${GraphConfig.webSocketsPrefix}?groupId=${this.chatId}&sessionId=${this.sessionId}`,
+        resource: resourcePath,
+        expirationDateTime,
+        includeResourceData: true,
+        clientState: 'wsssecret'
+      };
 
-    log('subscribing to changes for ' + resourcePath);
-    const subscriptionEndpoint = GraphConfig.subscriptionEndpoint;
-    // send subscription POST to Graph
-    const subscription: Subscription = (await this.subscriptionGraph
-      .api(subscriptionEndpoint)
-      .post(subscriptionDefinition)) as Subscription;
-    if (!subscription?.notificationUrl) throw new Error('Subscription not created');
-    log(subscription);
+      log('subscribing to changes for ' + resourcePath);
+      const subscriptionEndpoint = GraphConfig.subscriptionEndpoint;
+      // send subscription POST to Graph
+      const subscription: Subscription = (await this.subscriptionGraph
+        .api(subscriptionEndpoint)
+        .post(subscriptionDefinition)) as Subscription;
+      if (!subscription?.notificationUrl) throw new Error('Subscription not created');
+      log(subscription);
 
-    const awaits: Promise<void>[] = [];
-    // Cache the subscription in storage for re-hydration on page refreshes
-    awaits.push(this.cacheSubscription(subscription));
+      const awaits: Promise<void>[] = [];
+      // Cache the subscription in storage for re-hydration on page refreshes
+      awaits.push(this.cacheSubscription(subscription));
 
-    // create a connection to the web socket if one does not exist
-    if (!this.connection) awaits.push(this.createSignalRConnection(subscription.notificationUrl));
+      // create a connection to the web socket if one does not exist
+      if (!this.connection) awaits.push(this.createSignalRConnection(subscription.notificationUrl));
 
-    log('Invoked CreateSubscription');
-    return Promise.all(awaits);
+      log('Invoked CreateSubscription');
+      return Promise.all(awaits);
+    } catch (e) {
+      // this catches other unhandled exceptions such as when subscription.post fails
+      return Promise.reject(e);
+    }
   }
 
   private readonly startRenewalTimer = () => {
@@ -226,31 +233,35 @@ export class GraphNotificationClient {
   private readonly syncRenewalTimerWrapper = () => void this.renewalTimer();
 
   private readonly renewalTimer = async () => {
-    log(`running subscription renewal timer for chatId: ${this.chatId} sessionId: ${this.sessionId}`);
-    const subscriptions =
-      (await this.subscriptionCache.loadSubscriptions(this.chatId, this.sessionId))?.subscriptions || [];
-    if (subscriptions.length === 0) {
-      log(`No subscriptions found in session state. Stop renewal timer ${this.renewalTimeout}.`);
-      if (this.renewalTimeout) this.timer.clearTimeout(this.renewalTimeout);
-      return;
-    }
-
-    for (const subscription of subscriptions) {
-      if (!subscription.expirationDateTime) continue;
-      const expirationTime = new Date(subscription.expirationDateTime);
-      const now = new Date();
-      const diff = Math.round((expirationTime.getTime() - now.getTime()) / 1000);
-
-      if (diff <= appSettings.renewalThreshold) {
-        this.renewalCount++;
-        log(`Renewing Graph subscription. RenewalCount: ${this.renewalCount}`);
-        // stop interval to prevent new invokes until refresh is ready.
+    try {
+      log(`running subscription renewal timer for chatId: ${this.chatId} sessionId: ${this.sessionId}`);
+      const subscriptions =
+        (await this.subscriptionCache.loadSubscriptions(this.chatId, this.sessionId))?.subscriptions || [];
+      if (subscriptions.length === 0) {
+        log(`No subscriptions found in subscription cache. Stop renewal timer ${this.renewalTimeout}.`);
         if (this.renewalTimeout) this.timer.clearTimeout(this.renewalTimeout);
-        this.renewalTimeout = undefined;
-        await this.renewChatSubscriptions();
-        // There is one subscription that need expiration, all subscriptions will be renewed
-        break;
+        return;
       }
+
+      for (const subscription of subscriptions) {
+        if (!subscription.expirationDateTime) continue;
+        const expirationTime = new Date(subscription.expirationDateTime);
+        const now = new Date();
+        const diff = Math.round((expirationTime.getTime() - now.getTime()) / 1000);
+
+        if (diff <= appSettings.renewalThreshold) {
+          this.renewalCount++;
+          log(`Renewing Graph subscription for Chat. RenewalCount: ${this.renewalCount}`);
+          // stop interval to prevent new invokes until refresh is ready.
+          if (this.renewalTimeout) this.timer.clearTimeout(this.renewalTimeout);
+          this.renewalTimeout = undefined;
+          await this.renewChatSubscriptions();
+          // There is one subscription that need expiration, all subscriptions will be renewed
+          break;
+        }
+      }
+    } catch (e) {
+      error(e);
     }
     this.renewalTimeout = this.timer.setTimeout(this.syncRenewalTimerWrapper, appSettings.renewalTimerInterval * 1000);
   };
@@ -279,10 +290,14 @@ export class GraphNotificationClient {
 
   public renewSubscription = async (subscriptionId: string, expirationDateTime: string): Promise<void> => {
     // PATCH /subscriptions/{id}
-    const renewedSubscription = (await this.graph.api(`${GraphConfig.subscriptionEndpoint}/${subscriptionId}`).patch({
-      expirationDateTime
-    })) as Subscription;
-    return this.cacheSubscription(renewedSubscription);
+    try {
+      const renewedSubscription = (await this.graph.api(`${GraphConfig.subscriptionEndpoint}/${subscriptionId}`).patch({
+        expirationDateTime
+      })) as Subscription;
+      return this.cacheSubscription(renewedSubscription);
+    } catch (e) {
+      return Promise.reject(e);
+    }
   };
 
   public async createSignalRConnection(notificationUrl: string) {
@@ -338,23 +353,42 @@ export class GraphNotificationClient {
   };
 
   private readonly cleanupTimer = async () => {
-    log(`running cleanup timer`);
-    const offset = Math.min(
-      appSettings.removalThreshold * 1000,
-      appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
-    );
-    const threshold = new Date(new Date().getTime() - offset).toISOString();
-    const inactiveSubs = await this.subscriptionCache.loadInactiveSubscriptions(threshold, ComponentType.Chat);
-    let tasks: Promise<unknown>[] = [];
-    for (const inactive of inactiveSubs) {
-      tasks.push(this.removeSubscriptions(inactive.subscriptions));
+    try {
+      log(`running cleanup timer`);
+
+      // ensure there is a valid user
+      const id = await Providers.getCacheId();
+      if (!id) {
+        return;
+      }
+
+      // get the inactive subs (requires a user since the db is per user)
+      const offset = Math.min(
+        appSettings.removalThreshold * 1000,
+        appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000
+      );
+      const threshold = new Date(new Date().getTime() - offset).toISOString();
+      const inactiveSubs = await this.subscriptionCache.loadInactiveSubscriptions(threshold, ComponentType.Chat);
+
+      // remove all subscriptions
+      let tasks: Promise<unknown>[] = [];
+      for (const inactive of inactiveSubs) {
+        tasks.push(this.removeSubscriptions(inactive.subscriptions));
+      }
+      await Promise.all(tasks);
+
+      // delete the cache entries
+      tasks = [];
+      for (const inactive of inactiveSubs) {
+        tasks.push(this.subscriptionCache.deleteCachedSubscriptions(inactive.componentEntityId, inactive.sessionId));
+      }
+    } catch (e) {
+      // EXAMPLE: a user does a sign-out so `loadInactiveSubscriptions` no longer has a valid user and results
+      //    in an exception.
+      error(e);
+    } finally {
+      this.startCleanupTimer();
     }
-    await Promise.all(tasks);
-    tasks = [];
-    for (const inactive of inactiveSubs) {
-      tasks.push(this.subscriptionCache.deleteCachedSubscriptions(inactive.componentEntityId, inactive.sessionId));
-    }
-    this.startCleanupTimer();
   };
 
   public async closeSignalRConnection() {

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -231,7 +231,7 @@ export class GraphNotificationUserClient {
       const subscriptions =
         (await this.subscriptionCache.loadSubscriptions(this.currentUserId, this.sessionId))?.subscriptions || [];
       if (subscriptions.length === 0) {
-        log('No subscriptions found in session state. Creating a new subscription.');
+        log('No subscriptions found in subscription cache. Creating a new subscription.');
 
         await this.subscribeToResource(this.currentUserId, `/users/${this.currentUserId}/chats/getAllmessages`, [
           'created',
@@ -248,7 +248,7 @@ export class GraphNotificationUserClient {
 
           if (diff <= appSettings.renewalThreshold) {
             this.renewalCount++;
-            log(`Renewing Graph subscription. RenewalCount: ${this.renewalCount}.`);
+            log(`Renewing Graph subscription for ChatList. RenewalCount: ${this.renewalCount}.`);
 
             const newExpirationTime = new Date(
               new Date().getTime() + appSettings.defaultSubscriptionLifetimeInMinutes * 60 * 1000


### PR DESCRIPTION
Prior to this PR, when waking up from extended sleep, the chat would throw a number of unhandled errors which could go fullscreen in the browser.

This PR catches those errors and writes them to the log - ie. they are now handled.

It is worth noting that the chat doesn't work after waking up because of those errors - reworking that will be another ticket.