### PR TITLE
extend the delay in invoking the next renewal if we create a new subscription and get a 403

### DIFF
--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -25,6 +25,7 @@ import { GraphConfig } from './GraphConfig';
 import { SubscriptionsCache, ComponentType } from './Caching/SubscriptionCache';
 import { Timer } from '../utils/Timer';
 import { getOrGenerateGroupId } from './getOrGenerateGroupId';
+import { v4 as uuid } from 'uuid';
 
 export const appSettings = {
   defaultSubscriptionLifetimeInMinutes: 10,
@@ -319,6 +320,16 @@ export class GraphNotificationUserClient {
     return subscriptions.length > 0 ? subscriptions[0] : undefined;
   }
 
+  private getSessionId(): string {
+    let sessionId = sessionStorage.getItem('sessionId');
+    if (!sessionId) {
+      sessionId = uuid();
+      sessionStorage.setItem('sessionId', sessionId);
+    }
+    log(`ChatList session Id: ${sessionId}`);
+    return sessionId;
+  }
+
   private readonly renewSubscription = async (userId: string, subscription: Subscription): Promise<void> => {
     this.renewalCount++;
     log(`Renewing Graph subscription for ChatList. RenewalCount: ${this.renewalCount}.`);
@@ -344,7 +355,7 @@ export class GraphNotificationUserClient {
     };
 
     const connection = new HubConnectionBuilder()
-      .withUrl(GraphConfig.adjustNotificationUrl(notificationUrl), connectionOptions)
+      .withUrl(GraphConfig.adjustNotificationUrl(notificationUrl, this.getSessionId()), connectionOptions)
       .configureLogging(LogLevel.Information)
       .build();
 

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -320,14 +320,9 @@ export class GraphNotificationUserClient {
     return subscriptions.length > 0 ? subscriptions[0] : undefined;
   }
 
+  // this is used to create a unique session id for the web socket connection
   private getSessionId(): string {
-    let sessionId = sessionStorage.getItem('sessionId');
-    if (!sessionId) {
-      sessionId = uuid();
-      sessionStorage.setItem('sessionId', sessionId);
-    }
-    log(`ChatList session Id: ${sessionId}`);
-    return sessionId;
+    return uuid();
   }
 
   private readonly renewSubscription = async (userId: string, subscription: Subscription): Promise<void> => {

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -24,6 +24,7 @@ import type {
 import { GraphConfig } from './GraphConfig';
 import { SubscriptionsCache, ComponentType } from './Caching/SubscriptionCache';
 import { Timer } from '../utils/Timer';
+import { getOrGenerateGroupId } from './getOrGenerateGroupId';
 
 export const appSettings = {
   defaultSubscriptionLifetimeInMinutes: 10,
@@ -174,7 +175,8 @@ export class GraphNotificationUserClient {
   };
 
   private async createSubscription(userId: string): Promise<Subscription> {
-    log('Creating a new subscription.');
+    const groupId = getOrGenerateGroupId(userId);
+    log('Creating a new subscription with group Id:', groupId);
     const resourcePath = `/users/${userId}/chats/getAllmessages`;
     const changeTypes: ChangeTypes[] = ['created', 'updated', 'deleted'];
 
@@ -184,7 +186,7 @@ export class GraphNotificationUserClient {
     ).toISOString();
     const subscriptionDefinition: Subscription = {
       changeType: changeTypes.join(','),
-      notificationUrl: `${GraphConfig.webSocketsPrefix}?groupId=${userId}&sessionId=default`,
+      notificationUrl: `${GraphConfig.webSocketsPrefix}?groupId=${groupId}`,
       resource: resourcePath,
       expirationDateTime,
       includeResourceData: true,
@@ -221,6 +223,7 @@ export class GraphNotificationUserClient {
     this.currentUserId = this.userId;
 
     let isRenewalInError = false;
+    let nextRenewalTimeInMs = appSettings.renewalTimerInterval * 1000;
 
     try {
       let subscription = await this.getSubscription(this.currentUserId);
@@ -254,15 +257,27 @@ export class GraphNotificationUserClient {
       }
 
       if (!subscription) {
-        subscription = await this.createSubscription(this.currentUserId);
+        try {
+          subscription = await this.createSubscription(this.currentUserId);
+        } catch (e) {
+          subscription = undefined;
+          isRenewalInError = true;
+          error(e);
+
+          // rather than 3 seconds, back off to 10 seconds if we get a 403
+          if ((e as { statusCode?: number }).statusCode === 403) {
+            nextRenewalTimeInMs = 10 * 1000;
+          }
+        }
       }
 
       // notificationUrl comes in the form of websockets:https://graph.microsoft.com/beta/subscriptions/notificationChannel/websockets/<Id>?groupid=<UserId>&sessionid=default
       // if <Id> changes, we need to create a new connection
       if (
-        !this.connection ||
-        this.connection.state !== HubConnectionState.Connected ||
-        this.lastNotificationUrl !== subscription.notificationUrl
+        subscription &&
+        (!this.connection ||
+          this.connection.state !== HubConnectionState.Connected ||
+          this.lastNotificationUrl !== subscription.notificationUrl)
       ) {
         if (subscription.notificationUrl) {
           this.lastNotificationUrl = subscription.notificationUrl;
@@ -296,7 +311,7 @@ export class GraphNotificationUserClient {
     }
 
     this.isRewnewalInProgress = false;
-    this.renewalInterval = this.timer.setTimeout(this.renewalSync, appSettings.renewalTimerInterval * 1000);
+    this.renewalInterval = this.timer.setTimeout(this.renewalSync, nextRenewalTimeInMs);
   };
 
   private async getSubscription(userId: string): Promise<Subscription | undefined> {


### PR DESCRIPTION
This PR came up as a result of the possibility where we somehow exceed 10 subscription limits. The process will eventually self-recover - meaning the earlier subscriptions will expire naturally and we can create new subscription. Currently, we check renewal every 3 seconds, but we know when we get this error, it takes a bit of time to self-recover and hence extending the time to 10 seconds which was our earliest design, so we don't keep trying so frequently.

one other change in this PR was to make sure we are consistent with how Chat is creating a Subscription without group Id.