### PR TITLE
persist read messages state

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -134,13 +134,16 @@ export const ChatList = ({
   // we know what messages they are likely to have not read. This is not perfect because
   // the user could have read messages in another client (for instance, the Teams client).
   useEffect(() => {
-    const timer = setInterval(() => {
-      chatListClient?.cacheLastReadTime('selected');
-    }, lastReadTimeInterval);
+    // setup timer only after we have a defined chatListClient
+    if (chatListClient) {
+      const timer = setInterval(() => {
+        chatListClient.cacheLastReadTime('selected');
+      }, lastReadTimeInterval);
 
-    return () => {
-      clearInterval(timer);
-    };
+      return () => {
+        clearInterval(timer);
+      };
+    }
   }, [chatListClient, lastReadTimeInterval]);
 
   useEffect(() => {

--- a/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
+++ b/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
@@ -33,6 +33,9 @@ export class LastReadCache {
         // from getCacheId to remove the cache/db. If the id has no dashes, it will not be removed.
         return `mgt-lastreadcache-${id.replace(/-/g, '')}`;
       }
+
+      // needed for build error
+      throw new Error('CacheId is not available');
     };
     return cache;
   }

--- a/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
+++ b/packages/mgt-chat/src/statefulClient/Caching/LastReadCache.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { CacheItem, CacheSchema, CacheService, CacheStore, schemas } from '@microsoft/mgt-react';
+import { CacheItem, CacheSchema, CacheService, CacheStore, Providers, schemas } from '@microsoft/mgt-react';
 import { isConversationCacheEnabled } from './isConversationCacheEnabled';
 import { cacheEntryIsValid } from './cacheEntryIsValid';
 
@@ -25,7 +25,16 @@ interface LastReadData extends CacheItem {
 export class LastReadCache {
   private get cache(): CacheStore<LastReadData> {
     const conversation: CacheSchema = schemas.conversation;
-    return CacheService.getCache<LastReadData>(conversation, conversation.stores.lastRead);
+    const cache = CacheService.getCache<LastReadData>(conversation, conversation.stores.lastRead);
+    cache.getDBName = async () => {
+      const id = await Providers.getCacheId();
+      if (id) {
+        // this removal of dashes is done because when a user signs out, the code looks for contains matches
+        // from getCacheId to remove the cache/db. If the id has no dashes, it will not be removed.
+        return `mgt-lastreadcache-${id.replace(/-/g, '')}`;
+      }
+    };
+    return cache;
   }
 
   public async loadLastReadTime(chatId: string): Promise<LastReadData | null | undefined> {

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -250,12 +250,15 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
         ...chatThread,
         isRead: true
       };
+
       draft.chatThreads = state.chatThreads.map((c: GraphChatThread) => {
         if (c.id === chatThread.id && draft.internalSelectedChat) {
           return draft.internalSelectedChat;
         }
         return c;
       });
+
+      this.updateLastReadTime(draft.internalSelectedChat.id);
     });
   };
 
@@ -291,12 +294,16 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     // cache last read time after chat thread is found in current state
     if (action === 'selected') {
       const selectedChatId = state.internalSelectedChat?.id;
-      if (selectedChatId) {
-        log(`caching the last-read timestamp of now to chat ID '${selectedChatId}'...`);
-        void this._cache.cacheLastReadTime(selectedChatId, new Date());
-      }
+      this.updateLastReadTime(selectedChatId);
     }
   };
+
+  private updateLastReadTime(selectedChatId: string | undefined) {
+    if (selectedChatId) {
+      log(`caching the last-read timestamp of now to chat ID '${selectedChatId}'...`);
+      void this._cache.cacheLastReadTime(selectedChatId, new Date());
+    }
+  }
 
   // check whether to mark the chat as read or not
   private readonly checkWhetherToMarkAsRead = async (c: GraphChatThread[]): Promise<GraphChatThread[]> => {


### PR DESCRIPTION
- LastReadCache is using the same indexeddb for storing read messages. However, when a user logs out, the same indexeddb is removed (which we learned from PG) and what it appears to be when I checked the code. The fix is to use a dbname which is excluded from removal routine when user signs out
- When user clicks on a chatlistitem, we should also store the message as read in LastReadCache 