### PR TITLE
implemented state change tracking for chatThreadsPerPage and selectedChatId

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -274,7 +274,7 @@ export const ChatList = ({
     }
 
     return () => observer.disconnect();
-  }, [chatListState]);
+  }, [chatListClient, chatListState]);
 
   return (
     <FluentThemeProvider fluentTheme={FluentTheme}>

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -107,6 +107,7 @@ export const ChatList = ({
 }: MgtTemplateProps & IChatListProps & IChatListMenuItemsProps) => {
   const styles = useStyles();
 
+  const [initialLastReadTimeInterval, setInitialLastReadTimeInterval] = useState<number | undefined>();
   const [chatListClient, setChatListClient] = useState<StatefulGraphChatListClient | undefined>();
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
   const [chatListActions, setChatListActions] = useState<IChatListActions | undefined>();
@@ -163,6 +164,19 @@ export const ChatList = ({
   useEffect(() => {
     // setup timer only after we have a defined chatListClient
     if (chatListClient) {
+      if (initialLastReadTimeInterval) {
+        error('lastReadTimeInterval can only be set once.');
+        return;
+      }
+
+      if (lastReadTimeInterval < 1) {
+        error('lastReadTimeInterval must be greater than 0!');
+        return;
+      }
+
+      // todo: implement a upperbound limit for lastReadTimeInterval
+      setInitialLastReadTimeInterval(lastReadTimeInterval);
+
       const timer = setInterval(() => {
         chatListClient.cacheLastReadTime('selected');
       }, lastReadTimeInterval);

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -222,7 +222,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
         return;
       }
 
-      if (items.length < maxItems && handlerNextLink && handlerNextLink !== '') {
+      if (items.length < maxItems && handlerNextLink) {
         await this.loadAndAppendChatThreads(handlerNextLink, items, maxItems);
         return;
       }
@@ -230,7 +230,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
       this.handleChatThreads(items, handlerNextLink);
     };
 
-    if (nextLink === '') {
+    if (!nextLink) {
       // max page count cannot exceed 50 per documentation
       const pageCount = maxItems > 50 ? 50 : maxItems;
       loadChatThreads(this._graph, pageCount).then(handler, err => error(err));
@@ -602,9 +602,9 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     this.notifyStateChange((draft: GraphChatListClient) => {
       draft.status = chatThreads.length > 0 ? 'chats loaded' : 'no chats';
       draft.chatThreads = chatThreads;
-      draft.moreChatThreadsToLoad = nextLink !== undefined && nextLink !== '';
+      draft.moreChatThreadsToLoad = Boolean(nextLink);
       draft.fireOnSelected = false;
-      if (this._initialSelectedChatId && this._initialSelectedChatId !== '') {
+      if (this._initialSelectedChatId) {
         // again, we expect this code to only run once, during the init of ChatList component if and only if _initialSelectedChatId is set.
         const toFindId = this._initialSelectedChatId;
         const chat = chatThreads.find(c => c.id === toFindId);
@@ -679,7 +679,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
    * @memberof StatefulGraphChatListClient
    */
   private async updateUserSubscription(userId: string) {
-    if (userId === '') return;
+    if (!userId) return;
 
     // reset state to initial
     this.notifyStateChange((draft: GraphChatListClient) => {

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -84,7 +84,7 @@ export type GraphChatListClient = Pick<MessageThreadProps, 'userId'> & {
   moreChatThreadsToLoad: boolean | undefined;
   internalSelectedChat: GraphChatThread | undefined;
   internalPrevSelectedChat: GraphChatThread | undefined;
-  initialSelectedChatSet: boolean;
+  fireOnSelected: boolean; // takes care of a case when we first init ChatList and sets the selected chat Id but onselected is not fired.
 } & Pick<ErrorBarProps, 'activeErrorMessages'>;
 
 interface StatefulClient<T> {
@@ -104,7 +104,9 @@ interface StatefulClient<T> {
    * @param handler Callback to be unregistered
    */
   offStateChange(handler: (state: T) => void): void;
-
+  /**
+   * Provides the number of chat threads to display with each load more.
+   */
   chatThreadsPerPage: number;
   /**
    * Method for loading more chat threads
@@ -122,7 +124,12 @@ interface StatefulClient<T> {
    * Method for setting the currently selected chat
    * @param chatThread - currently selected chat
    */
-  setInternalSelectedChat(chatThread: GraphChatThread): void;
+  setSelectedChat(chatThread: GraphChatThread): void;
+  /**
+   * Method for setting the currently selected chat
+   * @param chatId - currently selected chat id
+   */
+  setSelectedChatId(chatId: string): void;
 }
 
 type MessageEventType =
@@ -161,15 +168,15 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   private readonly _graph: IGraph;
   private _stateSubscribers: ((state: GraphChatListClient) => void)[] = [];
   private _initialSelectedChatId: string | undefined;
-  constructor(chatThreadsPerPage: number, initialSelectedChatId: string | undefined) {
+
+  constructor() {
     this.userId = currentUserId();
     Providers.globalProvider.onActiveAccountChanged(this.onActiveAccountChanged);
     this._eventEmitter = new ThreadEventEmitter();
     this.registerEventListeners();
     this._cache = new LastReadCache();
     this._graph = graph('mgt-chat', GraphConfig.version);
-    this.chatThreadsPerPage = chatThreadsPerPage;
-    this._initialSelectedChatId = initialSelectedChatId;
+
     this._notificationClient = new GraphNotificationUserClient(this._eventEmitter, this._graph);
 
     void this.updateUserSubscription(this.userId);
@@ -178,7 +185,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   /**
    * Provides the number of chat threads to display with each load more.
    */
-  public chatThreadsPerPage: number;
+  public chatThreadsPerPage = 20;
 
   /**
    * Provides a method to clean up any resources being used internally when a consuming component is being removed from the DOM
@@ -233,7 +240,37 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     }
   }
 
-  public setInternalSelectedChat = (chatThread: GraphChatThread): void => {
+  public clearSelectedChat = () => {
+    const state = this.getState();
+
+    if (state.internalSelectedChat) {
+      this.notifyStateChange((draft: GraphChatListClient) => {
+        draft.status = 'chat unselected';
+        draft.internalPrevSelectedChat = state.internalSelectedChat;
+        draft.internalSelectedChat = undefined;
+      });
+    }
+  };
+
+  public setSelectedChatId = (chatId: string) => {
+    // the first time we are setting the selected chat, we may still be loading chat threads.
+    // so trying the code block after this will not work as there are no chat threads yet.
+    // we are setting this flag so that the `chats loaded` on ChatList can fire onselected.
+    if (!this._initialSelectedChatId) {
+      this._initialSelectedChatId = chatId;
+      return;
+    }
+
+    const state = this.getState();
+    if (!state.internalSelectedChat || state.internalSelectedChat.id !== chatId) {
+      const chatThread = state.chatThreads.find(c => c.id === chatId);
+      if (chatThread) {
+        this.setSelectedChat(chatThread);
+      }
+    }
+  };
+
+  public setSelectedChat = (chatThread: GraphChatThread): void => {
     const state = this.getState();
 
     if (state.internalSelectedChat) {
@@ -367,7 +404,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     chatMessage: undefined,
     internalSelectedChat: undefined,
     internalPrevSelectedChat: undefined,
-    initialSelectedChatSet: false
+    fireOnSelected: false
   };
 
   /**
@@ -566,10 +603,18 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
       draft.status = chatThreads.length > 0 ? 'chats loaded' : 'no chats';
       draft.chatThreads = chatThreads;
       draft.moreChatThreadsToLoad = nextLink !== undefined && nextLink !== '';
-      if (this._initialSelectedChatId) {
-        draft.internalSelectedChat = chatThreads.filter(c => c.id === this._initialSelectedChatId)[0];
-        this._initialSelectedChatId = undefined;
-        draft.initialSelectedChatSet = true;
+      draft.fireOnSelected = false;
+      if (this._initialSelectedChatId && this._initialSelectedChatId !== '') {
+        // again, we expect this code to only run once, during the init of ChatList component if and only if _initialSelectedChatId is set.
+        const toFindId = this._initialSelectedChatId;
+        const chat = chatThreads.find(c => c.id === toFindId);
+        this._initialSelectedChatId = ''; // ensure we only set the selected chat once
+        if (chat) {
+          draft.internalSelectedChat = chat;
+          draft.fireOnSelected = true;
+        } else {
+          log('Chat with id ' + toFindId + ' not found in loaded chat threads.');
+        }
       }
     });
   };

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -14,16 +14,39 @@ export const ChatAddIcon = (): JSX.Element => {
 };
 
 function App() {
-  const [chatId, setChatId] = useState<string>('');
+  let sessionChatId = sessionStorage.getItem('chatId') ?? '';
+  console.log('sessionChatId: ', sessionChatId);
+
+  const [chatId, setChatId] = useState<string>(sessionChatId);
   const [showNewChat, setShowNewChat] = useState<boolean>(false);
+  // we are using a different state to track the selected chat id fired from chat list.
+  const [selectedChatListChatId, setSelectedChatListChatId] = useState<string>('');
+
+  sessionStorage.clear();
+
+  const saveChatAndRefresh = () => {
+    if (chatId !== '') {
+      console.log('setting chatId: ', chatId);
+      sessionStorage.setItem('chatId', chatId);
+      // force a page refesh, this will test setting the initial chat id.
+      window.location.reload();
+    }
+  };
+
+  const clearSelectedChat = () => {
+    setChatId('');
+    setSelectedChatListChatId('');
+  };
 
   const onChatSelected = useCallback((e: GraphChatThread) => {
     console.log('Selected: ', e.id);
     setChatId(e.id ?? '');
+    setSelectedChatListChatId(e.id ?? '');
   }, []);
 
   const onChatCreated = useCallback((chat: GraphChat) => {
     setChatId(chat.id ?? '');
+    setSelectedChatListChatId(chat.id ?? '');
     setShowNewChat(false);
   }, []);
 
@@ -74,11 +97,15 @@ function App() {
       </header>
       <main className="main">
         <div className="chat-selector">
+          <button onClick={() => saveChatAndRefresh()}>Save selected chat and refresh</button>
           <br />
-          <button onClick={() => setChatId('')}>Clear selected chat</button>
+          <button onClick={() => clearSelectedChat()}>Clear selected chat</button>
           <br />
           <button onClick={() => setShowNewChat(true)}>New Chat</button>
-          Selected chat: {chatId}
+          <br />
+          Selected chat id: {chatId}
+          <br />
+          Selected chatlist chat id: {selectedChatListChatId}
           <br />
           {showNewChat && (
             <div className="new-chat">
@@ -88,6 +115,7 @@ function App() {
         </div>
         <div className="chatlist-pane">
           <ChatList
+            selectedChatId={chatId}
             onLoaded={onLoaded}
             chatThreadsPerPage={10}
             menuItems={menus}
@@ -100,7 +128,7 @@ function App() {
           />
         </div>
         {/* NOTE: removed the chatId guard as this case has an error state. */}
-        <div className="chat-pane">{<Chat chatId={chatId} />}</div>
+        <div className="chat-pane">{<Chat chatId={selectedChatListChatId} />}</div>
       </main>
     </div>
   );

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   console.log('sessionChatId: ', sessionChatId);
 
   const [chatId, setChatId] = useState<string>(sessionChatId);
+  const [chatThreadsPerPage, setChatThreadsPerPage] = useState<number>(10);
   const [showNewChat, setShowNewChat] = useState<boolean>(false);
   // we are using a different state to track the selected chat id fired from chat list.
   const [selectedChatListChatId, setSelectedChatListChatId] = useState<string>('');
@@ -88,6 +89,10 @@ function App() {
     console.log('Unselected: ', chatThread.id);
   }, []);
 
+  const handleChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setChatThreadsPerPage(parseInt(event.target.value));
+  }, []);
+
   return (
     <div className="App">
       <header className="App-header">
@@ -100,6 +105,16 @@ function App() {
           <button onClick={() => saveChatAndRefresh()}>Save selected chat and refresh</button>
           <br />
           <button onClick={() => clearSelectedChat()}>Clear selected chat</button>
+          <br />
+          <select value={chatThreadsPerPage} onChange={handleChange}>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="70">70</option>
+          </select>
+          <br />
+          Chat threads per page: {chatThreadsPerPage}
           <br />
           <button onClick={() => setShowNewChat(true)}>New Chat</button>
           <br />
@@ -117,7 +132,7 @@ function App() {
           <ChatList
             selectedChatId={chatId}
             onLoaded={onLoaded}
-            chatThreadsPerPage={10}
+            chatThreadsPerPage={chatThreadsPerPage}
             menuItems={menus}
             buttonItems={buttons}
             onSelected={onChatSelected}


### PR DESCRIPTION
- React chat sample has been updated to test setting the initial `selectedChatId`. The saveChatAndRefresh  function implemented in the button will attempt to persist the currently `selectedChatId` in session and then try retrieve it on page load, and set it to component, this will allow us to test if Chat thread is actually selected if set/provided initially.
- React chat sample has been updated to test setting `chatThreadsPerPage` during runtime using a dropdown. The dropdown contains the values 5,10,20,50,70 and defaults to 10. Normally, the code will attempt to grab the maximum number of chat threads, however, we should note that there is a paging limit in the API at 50, so if chat threads will invoke the API more than once if this limit is exceeded, which is why we have 70 as a count to select. Depending on your screen size as a factor and page count, if you attempt to test with 70, be prepared to have at least a reasonable number of chat threads to be safe to observe the behavior.

As a note, I did not consider allowing `lastReadTimeInterval` to be reset again because I don't think there is a use-case for updating this value after it is set. Operationally, it will cause some implications because this value is used in a timer and we will have to dispose the timer and reset it, which means we need to reference the timer now, so we need to consider the implications carefully. Not sure if this is worth it unless we can think of a use case for updating it at runtime.