### PR TITLE
Add filter to loadAppsInChat to exclude apps without a bot

### DIFF
--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -28,8 +28,6 @@ interface EventMessageDetailWithType {
   '@odata.type': string;
 }
 
-const ignoreBotsWithName = ['Updates'];
-
 const useStyles = makeStyles({
   // highlight selection
   isSelected: {
@@ -120,6 +118,8 @@ const useStyles = makeStyles({
     '--person-alignment': 'center'
   }
 });
+
+const IGNORE_BOTS_WITH_NAME = ['Updates'];
 
 // regex to match different tags
 const imageTagRegex = /(<img[^>]+)/;
@@ -262,7 +262,7 @@ export const ChatListItem = ({ chat, myId, isSelected, isRead }: IChatListItemPr
           a =>
             a.teamsAppDefinition?.bot?.id &&
             a.teamsAppDefinition?.displayName &&
-            ignoreBotsWithName.indexOf(a.teamsAppDefinition?.displayName) === -1
+            IGNORE_BOTS_WITH_NAME.indexOf(a.teamsAppDefinition?.displayName) === -1
         )
         .map(a => a.teamsAppDefinition!.displayName!);
       if (names.length > 0) {

--- a/packages/mgt-chat/src/statefulClient/graph.chat.ts
+++ b/packages/mgt-chat/src/statefulClient/graph.chat.ts
@@ -135,6 +135,7 @@ export const loadMoreChatMessages = async (graph: IGraph, nextLink: string): Pro
 export const loadAppsInChat = async (graph: IGraph, chatId: string): Promise<AppCollection> => {
   const response = (await graph
     .api(`/chats/${chatId}/installedApps`)
+    .filter('teamsAppDefinition/bot/id ne null')
     .expand('teamsAppDefinition($expand=bot)')
     .middlewareOptions(prepScopes(chatOperationScopes.loadAppsInChat))
     .get()) as AppCollection;

--- a/packages/mgt-chat/src/statefulClient/graph.chat.ts
+++ b/packages/mgt-chat/src/statefulClient/graph.chat.ts
@@ -132,7 +132,7 @@ export const loadMoreChatMessages = async (graph: IGraph, nextLink: string): Pro
   return response;
 };
 
-export const loadAppsInChat = async (graph: IGraph, chatId: string): Promise<AppCollection> => {
+export const loadBotsInChat = async (graph: IGraph, chatId: string): Promise<AppCollection> => {
   const response = (await graph
     .api(`/chats/${chatId}/installedApps`)
     .filter('teamsAppDefinition/bot/id ne null')


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Task 493
Tested in ChatList that loading a Bot chat calls the API with a filter now

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
