### PR TITLE
Harden sleep/wake experience for ChatList

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -111,7 +111,7 @@ export const ChatList = ({
   const [chatListClient, setChatListClient] = useState<StatefulGraphChatListClient | undefined>();
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
   const [chatListActions, setChatListActions] = useState<IChatListActions | undefined>();
-  const loadingRef = useRef(false);
+
   // wait for provider to be ready before setting client and state
   useEffect(() => {
     const provider = Providers.globalProvider;
@@ -214,8 +214,6 @@ export const ChatList = ({
 
       if (state.status === 'chats loaded' && onLoaded) {
         onLoaded(state?.chatThreads ?? []);
-        // the loadingRef is used to prevent multiple calls to loadMoreChatThreads
-        loadingRef.current = false;
       }
 
       if (state.status === 'chats loaded' && state.fireOnSelected && onSelected && state.internalSelectedChat) {
@@ -228,6 +226,7 @@ export const ChatList = ({
 
       if (state.status === 'server connection established' && onConnectionChanged) {
         onConnectionChanged(true);
+        chatListClient.tryLoadChatThreads().catch(e => chatListClient.raiseFatalError(e as Error));
       }
 
       if (state.status === 'server connection lost' && onConnectionChanged) {
@@ -256,33 +255,31 @@ export const ChatList = ({
   const chatListButtonItems = props.buttonItems === undefined ? [] : props.buttonItems;
   const chatListMenuItems = props.menuItems === undefined ? [] : props.menuItems;
 
-  const isLoading = ['creating server connections', 'subscribing to notifications', 'loading messages'].includes(
+  const isLoading = ['creating server connections', 'subscribing to notifications', 'loading chats'].includes(
     chatListState?.status ?? ''
   );
 
   const targetElementRef = useRef(null);
 
   useEffect(() => {
+    // define the intersection observer callback
     const handleIntersection = (entries: IntersectionObserverEntry[]) => {
       for (const entry of entries) {
-        if (entry.isIntersecting) {
-          // The element has come into view, you can perform your actions here
-          if (chatListClient && !loadingRef.current) {
-            // Prevent the function from being called multiple times
-            if (chatListState?.moreChatThreadsToLoad) {
-              void chatListClient.loadMoreChatThreads().then(() => (loadingRef.current = true));
-            }
-          }
+        // The element has come into view, you can perform your actions here
+        if (entry.isIntersecting && chatListClient) {
+          chatListClient.tryLoadMoreChatThreads().catch(e => error('Failed to load more chat threads.', e));
         }
       }
     };
-    // Create a new Intersection Observer instance
+
+    // create a new Intersection Observer instance
     const observer = new IntersectionObserver(handleIntersection, {
       root: null, // observing intersections with the viewport
       rootMargin: '0px',
       threshold: 0.03 // Callback is invoked when 3% of the target is visible
     });
 
+    // start observing
     if (targetElementRef.current) {
       observer.observe(targetElementRef.current);
     }

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -56,13 +56,12 @@ const isMembershipNotification = (o: Notification<Entity>): o is Notification<Aa
   o.resource.includes('/members');
 
 export class GraphNotificationUserClient {
+  private readonly instanceId = uuid();
   private connection?: HubConnection = undefined;
-  private renewalInterval?: string;
+  private renewalTimeout?: string;
   private renewalCount = 0;
-  private isRewnewalInProgress = false;
   private wasConnected?: boolean | undefined;
   private userId = '';
-  private currentUserId = '';
   private lastNotificationUrl = '';
 
   private readonly subscriptionCache: SubscriptionsCache = new SubscriptionsCache();
@@ -93,7 +92,9 @@ export class GraphNotificationUserClient {
    * i.e
    */
   public tearDown() {
-    void this.unsubscribeFromUserNotifications(this.userId);
+    log('cleaning up graph user notification resources');
+    if (this.renewalTimeout) this.timer.clearTimeout(this.renewalTimeout);
+    this.timer.close();
   }
 
   private readonly getToken = async () => {
@@ -210,109 +211,130 @@ export class GraphNotificationUserClient {
     return subscription;
   }
 
+  private async deleteCachedSubscriptions(userId: string) {
+    try {
+      log('Removing all user subscriptions from cache...');
+      await this.subscriptionCache.deleteCachedSubscriptions(userId);
+      log('Successfully removed all user subscriptions from cache.');
+    } catch (e) {
+      error('Failed to remove all user subscriptions from cache.', e);
+    }
+  }
+
+  private trySwitchToConnected() {
+    if (!this.wasConnected) {
+      log('The user can now receive notifications from the user subscription.');
+      this.wasConnected = true;
+      this.emitter?.connected();
+    }
+  }
+
+  private trySwitchToDisconnected() {
+    if (this.wasConnected) {
+      log('The user can no receive notifications from the user subscription.');
+      this.wasConnected = false;
+      this.emitter?.disconnected();
+    }
+  }
+
   private readonly renewalSync = () => {
     void this.renewal();
   };
 
   private readonly renewal = async () => {
-    if (this.isRewnewalInProgress) {
-      log('Renewal already in progress');
-      return;
-    }
-
-    this.isRewnewalInProgress = true;
-    this.currentUserId = this.userId;
-
-    let isRenewalInError = false;
-    let nextRenewalTimeInMs = appSettings.renewalTimerInterval * 1000;
-
+    let nextRenewalTimeInSec = appSettings.renewalTimerInterval;
     try {
-      let subscription = await this.getSubscription(this.currentUserId);
+      const currentUserId = this.userId;
 
+      // if there is a current subscription...
+      let subscription = await this.getSubscription(currentUserId);
       if (subscription) {
-        if (!subscription.expirationDateTime || !subscription.id) {
-          // this should never happen.
-          throw new Error('Subscription is invalid.');
-        }
-
+        // attempt a renewal if necessary
         try {
-          const expirationTime = new Date(subscription.expirationDateTime);
-          const now = new Date();
-          const diff = Math.round((expirationTime.getTime() - now.getTime()) / 1000);
-
-          if (diff <= appSettings.renewalThreshold) {
-            await this.renewSubscription(this.currentUserId, subscription);
+          const expirationTime = new Date(subscription.expirationDateTime!);
+          const diff = Math.round((expirationTime.getTime() - new Date().getTime()) / 1000);
+          if (diff <= 0) {
+            log(`Renewing user subscription ${subscription.id!} that has already expired...`);
+            this.trySwitchToDisconnected();
+            await this.renewSubscription(currentUserId, subscription);
+            log(`Successfully renewed user subscription ${subscription.id!}.`);
+          } else if (diff <= appSettings.renewalThreshold) {
+            log(`Renewing user subscription ${subscription.id!} that will expire in ${diff} seconds...`);
+            await this.renewSubscription(currentUserId, subscription);
+            log(`Successfully renewed user subscription ${subscription.id!}.`);
           }
-        } catch (renewalEx) {
-          isRenewalInError = true;
-          // this error indicates we are not able to successfully renew the subscription, so we should create a new one.
-          if ((renewalEx as { statusCode?: number }).statusCode === 404) {
-            log('Removing subscription from cache');
-            await this.subscriptionCache.deleteCachedSubscriptions(this.currentUserId);
-            subscription = undefined;
-          } else {
-            // log and continue (we will try again later)
-            error(renewalEx);
-          }
+        } catch (e) {
+          error(`Failed to renew user subscription ${subscription.id!}.`, e);
+          await this.deleteCachedSubscriptions(currentUserId);
+          subscription = undefined;
         }
       }
 
+      // if there is no subscription, try to create one
       if (!subscription) {
         try {
-          subscription = await this.createSubscription(this.currentUserId);
+          this.trySwitchToDisconnected();
+          subscription = await this.createSubscription(currentUserId);
         } catch (e) {
-          subscription = undefined;
-          isRenewalInError = true;
-          error(e);
-
-          // rather than 3 seconds, back off to 10 seconds if we get a 403
-          if ((e as { statusCode?: number }).statusCode === 403) {
-            nextRenewalTimeInMs = 10 * 1000;
+          const err = e as { statusCode?: number; message: string };
+          if (err.statusCode === 403 && err.message.indexOf('has reached its limit') > 0) {
+            // if the limit is reached, back-off (NOTE: this should probably be a 429)
+            nextRenewalTimeInSec = appSettings.renewalTimerInterval * 3;
+            throw new Error(
+              `Failed to create a new subscription due to a limitation; retrying in ${nextRenewalTimeInSec} seconds: ${err.message}.`
+            );
+          } else if (err.statusCode === 403) {
+            // if true 403, stop renewal
+            error('Failed to create a new subscription due to a permanent condition; stopping renewals.', e);
+            return; // exit without setting the next renewal timer
+          } else {
+            // transient error, retry
+            throw new Error(
+              `Failed to create a new subscription due to a transient condition; retrying in ${nextRenewalTimeInSec} seconds: ${err.message}.`
+            );
           }
         }
       }
 
+      // create or reconnect the SignalR connection
       // notificationUrl comes in the form of websockets:https://graph.microsoft.com/beta/subscriptions/notificationChannel/websockets/<Id>?groupid=<UserId>&sessionid=default
       // if <Id> changes, we need to create a new connection
-      if (
-        subscription &&
-        (!this.connection ||
-          this.connection.state !== HubConnectionState.Connected ||
-          this.lastNotificationUrl !== subscription.notificationUrl)
-      ) {
-        if (subscription.notificationUrl) {
-          this.lastNotificationUrl = subscription.notificationUrl;
-          await this.createSignalRConnection(subscription.notificationUrl);
-        } else {
-          // this should never happen.
-          throw new Error('Subscription notificationUrl is invalid.');
-        }
+      log(`Checking SignalR connection for subscription ${subscription.id!} [${this.connection?.state}]...`); // todo: remove this
+      if (this.connection?.state === HubConnectionState.Connected) {
+        await this.connection?.send('ping'); // ensure the connection is still alive
       }
+      if (!this.connection) {
+        log(`Creating a new SignalR connection for subscription ${subscription.id!}...`);
+        this.trySwitchToDisconnected();
+        this.lastNotificationUrl = subscription.notificationUrl!;
+        await this.createSignalRConnection(subscription.notificationUrl!);
+        log(`Successfully created a new SignalR connection for subscription ${subscription.id!}.`);
+      } else if (this.connection.state !== HubConnectionState.Connected) {
+        log(`Reconnecting SignalR connection for subscription ${subscription.id!}...`);
+        this.trySwitchToDisconnected();
+        await this.connection.start();
+        log(`Successfully reconnected SignalR connection for subscription ${subscription.id!}.`);
+      } else if (this.lastNotificationUrl !== subscription.notificationUrl) {
+        log(`Updating SignalR connection for subscription ${subscription.id!} due to new notification URL...`);
+        this.trySwitchToDisconnected();
+        await this.closeSignalRConnection();
+        this.lastNotificationUrl = subscription.notificationUrl!;
+        await this.createSignalRConnection(subscription.notificationUrl!);
+        log(`Successfully updated SignalR connection for subscription ${subscription.id!}.`);
+      }
+      log(`Done checking SignalR connection for subscription ${subscription.id!}.`); // todo: remove this
+
+      // emit the new connection event if necessary
+      this.trySwitchToConnected();
     } catch (e) {
-      isRenewalInError = true;
-      // log and continue (we will try again later)
-      error(e);
+      error('Error in user subscription connection process.', e);
+      this.trySwitchToDisconnected();
     }
-
-    const isConnected = !isRenewalInError && this.connection?.state === HubConnectionState.Connected;
-    if (this.wasConnected !== isConnected) {
-      this.wasConnected = isConnected;
-      const emitter: ThreadEventEmitter | undefined = this.emitter;
-
-      try {
-        if (isConnected) {
-          emitter?.connected();
-        } else {
-          emitter?.disconnected();
-        }
-      } catch (e) {
-        // log emitter thrown exception and continue
-        error(e);
-      }
-    }
-
-    this.isRewnewalInProgress = false;
-    this.renewalInterval = this.timer.setTimeout(this.renewalSync, nextRenewalTimeInMs);
+    this.renewalTimeout = this.timer.setTimeout(
+      'renewal:' + this.instanceId,
+      this.renewalSync,
+      nextRenewalTimeInSec * 1000
+    );
   };
 
   private async getSubscription(userId: string): Promise<Subscription | undefined> {
@@ -342,8 +364,6 @@ export class GraphNotificationUserClient {
   };
 
   private async createSignalRConnection(notificationUrl: string) {
-    log('Creating SignalR connection');
-
     const connectionOptions: IHttpConnectionOptions = {
       accessTokenFactory: this.getToken,
       withCredentials: false
@@ -358,12 +378,7 @@ export class GraphNotificationUserClient {
     connection.on('EchoMessage', log);
 
     this.connection = connection;
-    try {
-      await connection.start();
-      log(connection);
-    } catch (e) {
-      error('An error occurred connecting to the notification web socket', e);
-    }
+    await connection.start();
   }
 
   private async deleteSubscription(id: string) {
@@ -387,29 +402,19 @@ export class GraphNotificationUserClient {
 
   public async closeSignalRConnection() {
     // stop the connection and set it to undefined so it will reconnect when next subscription is created.
-    await this.connection?.stop();
+    this.trySwitchToDisconnected();
+    try {
+      await this.connection?.stop();
+    } catch (e) {
+      error('Error closing a prior SignalR connection.', e);
+    }
     this.connection = undefined;
   }
 
-  public async unsubscribeFromUserNotifications(userId: string) {
-    if (this.renewalInterval) {
-      this.timer.clearTimeout(this.renewalInterval);
-    }
-
-    await this.closeSignalRConnection();
-    const cacheData = await this.subscriptionCache.loadSubscriptions(userId);
-    if (cacheData) {
-      await Promise.all([
-        this.removeSubscriptions(cacheData.subscriptions),
-        this.subscriptionCache.deleteCachedSubscriptions(userId)
-      ]);
-    }
-  }
-
-  public async subscribeToUserNotifications(userId: string) {
+  public subscribeToUserNotifications(userId: string) {
     log(`User subscription with id: ${userId}`);
     this.wasConnected = undefined;
     this.userId = userId;
-    await this.renewal();
+    this.renewalTimeout = this.timer.setTimeout('renewal:' + this.instanceId, this.renewalSync, 0);
   }
 }

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -299,7 +299,6 @@ export class GraphNotificationUserClient {
       // create or reconnect the SignalR connection
       // notificationUrl comes in the form of websockets:https://graph.microsoft.com/beta/subscriptions/notificationChannel/websockets/<Id>?groupid=<UserId>&sessionid=default
       // if <Id> changes, we need to create a new connection
-      log(`Checking SignalR connection for subscription ${subscription.id!} [${this.connection?.state}]...`); // todo: remove this
       if (this.connection?.state === HubConnectionState.Connected) {
         await this.connection?.send('ping'); // ensure the connection is still alive
       }
@@ -322,7 +321,6 @@ export class GraphNotificationUserClient {
         await this.createSignalRConnection(subscription.notificationUrl!);
         log(`Successfully updated SignalR connection for subscription ${subscription.id!}.`);
       }
-      log(`Done checking SignalR connection for subscription ${subscription.id!}.`); // todo: remove this
 
       // emit the new connection event if necessary
       this.trySwitchToConnected();

--- a/packages/mgt-chat/src/utils/Timer.ts
+++ b/packages/mgt-chat/src/utils/Timer.ts
@@ -5,7 +5,6 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { v4 as uuid } from 'uuid';
 import { TimerWork } from './timerWorker';
 
 export interface Work {
@@ -21,10 +20,12 @@ export class Timer {
     this.worker.port.onmessage = this.onMessage;
   }
 
-  public setTimeout(callback: () => void, delay: number): string {
+  // NOTE: this.work was increasing in size every time there was a new timeout because id was uuid()
+  // but clearTimeout was only being called on teardown.
+  public setTimeout(id: string, callback: () => void, delay: number): string {
     const timeoutWork: TimerWork = {
       type: 'setTimeout',
-      id: uuid(),
+      id,
       delay
     };
 
@@ -46,6 +47,8 @@ export class Timer {
     }
   }
 
+  /*
+  // NOTE: setInterval is not used in the library, but it is here for reference
   public setInterval(callback: () => void, delay: number): string {
     const intervalWork: TimerWork = {
       type: 'setInterval',
@@ -70,6 +73,7 @@ export class Timer {
       this.work.delete(id);
     }
   }
+  */
 
   private readonly onMessage = (event: MessageEvent<TimerWork>): void => {
     const intervalWork = event.data;


### PR DESCRIPTION
NOTE: This only applies to ChatList; Chat still has issues.

It seems that if you have 16 GB of RAM or less, you don't run into problems waking-up because the page gets unloaded and reloaded. However, if you have more memory, then the following conditions were observed after waking back up from a sleep:
- It took a long time for the solution to detect the disconnected state (30 seconds, sometimes minutes)
- It took a long time for the solution to reconnect and often never did (8-15 minutes)
- Loading the chat list after reconnection often failed
- A lot of stuff was happening in the renewal loops that wasn't logged making debug more difficult
- The entire renewal loop was not covered by a try...catch which introduces the possibility that the next loop isn't scheduled

Here are some things that were fixed in this PR:
- Loading chats and loading more chats are now more resilient to failure
- Loading chats now clears the list and displays the loading indicator for better user visibility
- Loading chats and loading more chats now more appropriately handle parallelism
- Timers were previously building an infinite list of functions in a map; now they don't
- The renewal loop logic path is now easier to follow - exception on disconnected, no exception when connected
- The renewal loop now changes to disconnection state as soon as it knows there is a problem rather than waiting for the loop to finish (which could take minutes)
- Improved next steps after subscription creation failure
- Varied the logic for how to handle SignalR connection issues
- Removed unsubscribeFromUserNotifications() in keeping with new Chat behavior
- Teardown processes now mimic Chat

What still isn't addressed:
- ~~I observed a few times waking up from a long sleep (hours), the renewal loop was no longer running.~~ I think this is actually related to the user getting logged off. Outside of that, I have not observed any other issues.