### PR TITLE
Feedback for ChatListItem

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -313,7 +313,7 @@ export const ChatList = ({
                       <ChatListItem
                         key={c.id}
                         chat={c}
-                        myId={chatListState.userId}
+                        userId={chatListState.userId}
                         isSelected={c.id === chatListState?.internalSelectedChat?.id}
                         isRead={c.isRead}
                       />

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -17,7 +17,7 @@ import { GraphChatThread } from '../../statefulClient/StatefulGraphChatListClien
 
 interface IChatListItemProps {
   chat: GraphChatThread;
-  myId: string | undefined;
+  userId: string | undefined;
   isSelected: boolean;
   isRead: boolean;
 }
@@ -124,7 +124,7 @@ const imageTagRegex = /(<img[^>]+)/;
 const attachmentTagRegex = /(<attachment[^>]+)/;
 const systemEventTagRegex = /(<systemEventMessage[^>]+)/;
 
-export const ChatListItem = ({ chat, myId, isSelected, isRead }: IChatListItemProps) => {
+export const ChatListItem = ({ chat, userId: myId, isSelected, isRead }: IChatListItemProps) => {
   const styles = useStyles();
 
   // manage the internal state of the chat

--- a/packages/mgt-chat/src/components/ChatListItem/DefaultProfileIcon.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/DefaultProfileIcon.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { makeStyles, shorthands } from '@fluentui/react-components';
 import { ChatListItemIcon } from '../ChatListItemIcon/ChatListItemIcon';
+import { Chat, AadUserConversationMember } from '@microsoft/microsoft-graph-types';
+import { Person } from '@microsoft/mgt-react';
 import { MgtTemplateProps } from '@microsoft/mgt-react';
+
+interface IDefaultProfileIconProps {
+  chat: Chat;
+  userId: string;
+}
 
 const useStyles = makeStyles({
   defaultProfileImage: {
@@ -10,11 +17,39 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center'
+  },
+
+  person: {
+    '--person-avatar-size': '32px',
+    '--person-alignment': 'center'
   }
 });
 
-export const DefaultProfileIcon = (_: MgtTemplateProps) => {
+export const DefaultProfileIcon = ({ chat, userId }: IDefaultProfileIconProps & MgtTemplateProps) => {
   const styles = useStyles();
-  const oneOnOneProfilePicture = <ChatListItemIcon chatType="oneOnOne" />;
-  return <div className={styles.defaultProfileImage}>{oneOnOneProfilePicture}</div>;
+
+  const otherAad = useCallback(() => {
+    const other = chat.members?.find(m => (m as AadUserConversationMember).userId !== userId);
+    return other as AadUserConversationMember;
+  }, [chat, userId]);
+
+  return (
+    <>
+      {chat.chatType === 'oneOnOne' && (
+        <Person
+          className={styles.person}
+          userId={otherAad()?.userId ?? undefined}
+          avatarSize="small"
+          showPresence={true}
+          personCardInteraction="hover"
+        >
+          <div className={styles.defaultProfileImage}>
+            <ChatListItemIcon chatType="oneOnOne" />
+          </div>
+        </Person>
+      )}
+      {chat.chatType === 'group' && <ChatListItemIcon chatType="group" />}
+      {chat.chatType === 'meeting' && <ChatListItemIcon chatType="meeting" />}
+    </>
+  );
 };

--- a/packages/mgt-chat/src/components/ChatListItem/DefaultProfileIcon.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/DefaultProfileIcon.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { ChatListItemIcon } from '../ChatListItemIcon/ChatListItemIcon';
 import { Chat, AadUserConversationMember } from '@microsoft/microsoft-graph-types';
 import { Person } from '@microsoft/mgt-react';
@@ -11,14 +11,6 @@ interface IDefaultProfileIconProps {
 }
 
 const useStyles = makeStyles({
-  defaultProfileImage: {
-    ...shorthands.borderRadius('50%'),
-    objectFit: 'cover',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
-
   person: {
     '--person-avatar-size': '32px',
     '--person-alignment': 'center'
@@ -43,9 +35,7 @@ export const DefaultProfileIcon = ({ chat, userId }: IDefaultProfileIconProps & 
           showPresence={true}
           personCardInteraction="hover"
         >
-          <div className={styles.defaultProfileImage}>
-            <ChatListItemIcon chatType="oneOnOne" />
-          </div>
+          <ChatListItemIcon chatType="oneOnOne" template="no-data" />
         </Person>
       )}
       {chat.chatType === 'group' && <ChatListItemIcon chatType="group" />}

--- a/packages/mgt-chat/src/components/ChatListItemIcon/ChatListItemIcon.tsx
+++ b/packages/mgt-chat/src/components/ChatListItemIcon/ChatListItemIcon.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
 import { Chat } from '@microsoft/microsoft-graph-types';
+import { makeStyles, shorthands } from '@fluentui/react-components';
 import { CalendarLtr24Regular, PeopleTeam24Regular, Person24Regular, bundleIcon } from '@fluentui/react-icons';
 import { error } from '@microsoft/mgt-element';
 import { Circle } from '../Circle/Circle';
+import { MgtTemplateProps } from '@microsoft/mgt-react';
+
+const useStyles = makeStyles({
+  defaultProfileImage: {
+    ...shorthands.borderRadius('50%'),
+    objectFit: 'cover',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});
 
 const GroupIcon = bundleIcon(PeopleTeam24Regular, PeopleTeam24Regular);
 const PersonIcon = bundleIcon(Person24Regular, Person24Regular);
 const MeetingIcon = bundleIcon(CalendarLtr24Regular, CalendarLtr24Regular);
-export const ChatListItemIcon = ({ chatType }: Chat): JSX.Element | null => {
+
+export const ChatListItemIcon = ({ chatType }: Chat & MgtTemplateProps): JSX.Element | null => {
+  const styles = useStyles();
   if (!chatType) return null;
 
   const iconColor = 'var(--colorBrandForeground2)';
@@ -21,9 +35,11 @@ export const ChatListItemIcon = ({ chatType }: Chat): JSX.Element | null => {
       );
     case 'oneOnOne':
       return (
-        <Circle>
-          <PersonIcon color={iconColor} />
-        </Circle>
+        <div className={styles.defaultProfileImage}>
+          <Circle>
+            <PersonIcon color={iconColor} />
+          </Circle>
+        </div>
       );
     case 'group':
       return (

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -645,7 +645,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
           isRead: false
         };
         draft.chatThreads.unshift(newChatThread);
-        // lazy load more info
+        // async load more info
         void this.loadChatDetails(event.message.chatId);
       } else {
         log(`received unrecognized event type '${event.type}' from the user subscription.`);
@@ -653,18 +653,18 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
     });
   }
 
-  private async loadChatDetails(id: string) {
+  private async loadChatDetails(chatId: string) {
     try {
-      const loaded = await loadChatWithPreview(this._graph, id);
+      const loaded = await loadChatWithPreview(this._graph, chatId);
       this.notifyStateChange((draft: GraphChatListClient) => {
         draft.status = 'chat details loaded';
-        const chatThread = draft.chatThreads?.findIndex(c => c.id === id) ?? -1;
+        const chatThread = draft.chatThreads?.findIndex(c => c.id === chatId) ?? -1;
         if (chatThread > -1) {
           draft.chatThreads[chatThread] = Object.assign(draft.chatThreads[chatThread], loaded);
         }
       });
     } catch (e) {
-      error(`Failed to load chat details for chat ID ${id}.`, e);
+      error(`Failed to load chat details for chat ID ${chatId}.`, e);
     }
   }
 
@@ -829,7 +829,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
       draft.status = 'creating server connections';
     });
     try {
-      void this._notificationClient.subscribeToUserNotifications(userId);
+      this._notificationClient.subscribeToUserNotifications(userId);
     } catch (e) {
       error('Failed to load chat data or subscribe to notications: ', e);
       if (e instanceof GraphError) {


### PR DESCRIPTION
This PR addresses comments from Gavin on ChatListItem:
- ChatListItem no longer stores chatInternal state and is no longer responsible for loading additional chat details
- The loading of additional chat details is now part of StatefulGraphChatListClient
- The DefaultProfileIcon now encompasses all logic related to that component
- It was suggested that the regex should use common logic but I never found any other place using these regex