### PR TITLE
Feedback for ChatList

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -221,7 +221,6 @@ export const ChatList = ({
     return () => {
       // log state of chatlistclient for debugging purposes
       log('ChatList unmounted.', chatListClient.getState());
-      chatListClient.offStateChange(setChatListState);
       chatListClient.tearDown();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { ChatListItem } from '../ChatListItem/ChatListItem';
 import { MgtTemplateProps, ProviderState, Providers, Spinner, log, error } from '@microsoft/mgt-react';
 import { makeStyles, Button, FluentProvider, shorthands, webLightTheme } from '@fluentui/react-components';
@@ -16,7 +16,6 @@ import { ChatListButtonItem } from '../ChatListHeader/ChatListButtonItem';
 import { Error } from '../Error/Error';
 import { LoadingMessagesErrorIcon } from '../Error/LoadingMessageErrorIcon';
 import { CreateANewChat } from '../Error/CreateANewChat';
-import { PleaseSignIn } from '../Error/PleaseSignIn';
 import { OpenTeamsLinkError } from '../Error/OpenTeams';
 import IChatListActions from '../ChatListHeader/IChatListActions';
 
@@ -112,15 +111,14 @@ export const ChatList = ({
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
   const [chatListActions, setChatListActions] = useState<IChatListActions | undefined>();
 
-  // todo: assume we are signed in when this component is mounted, remove auth guard.
   // wait for provider to be ready before setting client and state
   useEffect(() => {
     const provider = Providers.globalProvider;
     const conditionalLoad = (state: ProviderState | undefined) => {
-      if (state === ProviderState.SignedIn && !chatListClient) {
+      if (!chatListClient) {
         const client = new StatefulGraphChatListClient();
+        client.onStateChange(setChatListState);
         setChatListClient(client);
-        setChatListState(client.getState());
       }
     };
     provider?.onStateChanged(evt => {
@@ -188,55 +186,54 @@ export const ChatList = ({
     }
   }, [chatListClient, lastReadTimeInterval]); // todo: add doc to indicate why we are not adding deps
 
-  // todo: replace onstatechange w/ useEffect for chatListState
   // todo: implement offStateChange on line 199
   useEffect(() => {
-    // shortcut if we don't have a chat list client
-    if (!chatListClient) {
+    if (!chatListState) {
       return;
     }
 
     // handle state changes
-    chatListClient.onStateChange(setChatListState);
-    chatListClient.onStateChange(state => {
-      if (state.status === 'chat message received' && onMessageReceived && state.chatMessage) {
-        onMessageReceived(state.chatMessage);
-      }
+    if (chatListState.status === 'chat message received' && onMessageReceived && chatListState.chatMessage) {
+      onMessageReceived(chatListState.chatMessage);
+    }
 
-      if (state.status === 'chat selected' && onSelected && state.internalSelectedChat) {
-        onSelected(state.internalSelectedChat);
-      }
+    if (chatListState.status === 'chat selected' && onSelected && chatListState.internalSelectedChat) {
+      onSelected(chatListState.internalSelectedChat);
+    }
 
-      if (state.status === 'chat unselected' && onUnselected && state.internalPrevSelectedChat) {
-        onUnselected(state.internalPrevSelectedChat);
-      }
+    if (chatListState.status === 'chat unselected' && onUnselected && chatListState.internalPrevSelectedChat) {
+      onUnselected(chatListState.internalPrevSelectedChat);
+    }
 
-      if (state.status === 'chats read' && onAllMessagesRead && state.chatThreads) {
-        onAllMessagesRead(state.chatThreads.map(c => c.id!));
-      }
+    if (chatListState.status === 'chats read' && onAllMessagesRead && chatListState.chatThreads) {
+      onAllMessagesRead(chatListState.chatThreads.map(c => c.id!));
+    }
 
-      if (state.status === 'chats loaded' && onLoaded) {
-        onLoaded(state?.chatThreads ?? []);
-      }
+    if (chatListState.status === 'chats loaded' && onLoaded) {
+      onLoaded(chatListState?.chatThreads ?? []);
+    }
 
-      if (state.status === 'chats loaded' && state.fireOnSelected && onSelected && state.internalSelectedChat) {
-        onSelected(state.internalSelectedChat);
-      }
+    if (
+      chatListState.status === 'chats loaded' &&
+      chatListState.fireOnSelected &&
+      onSelected &&
+      chatListState.internalSelectedChat
+    ) {
+      onSelected(chatListState.internalSelectedChat);
+    }
 
-      if (state.status === 'no chats' && onLoaded) {
-        onLoaded([]);
-      }
+    if (chatListState.status === 'no chats' && onLoaded) {
+      onLoaded([]);
+    }
 
-      if (state.status === 'server connection established' && onConnectionChanged) {
-        onConnectionChanged(true);
-        chatListClient.tryLoadChatThreads().catch(e => chatListClient.raiseFatalError(e as Error));
-      }
+    if (chatListState.status === 'server connection established' && onConnectionChanged) {
+      onConnectionChanged(true);
+    }
 
-      if (state.status === 'server connection lost' && onConnectionChanged) {
-        onConnectionChanged(false);
-      }
-    });
-  }, [chatListClient, onLoaded, onMessageReceived, onSelected, onUnselected, onAllMessagesRead, onConnectionChanged]);
+    if (chatListState.status === 'server connection lost' && onConnectionChanged) {
+      onConnectionChanged(false);
+    }
+  }, [chatListState, onLoaded, onMessageReceived, onSelected, onUnselected, onAllMessagesRead, onConnectionChanged]);
 
   // this only runs once when the component is unmounted
   useEffect(() => {
@@ -251,10 +248,14 @@ export const ChatList = ({
     }
   }, []); // todo: add doc to indicate why we are not adding deps
 
-  // todo: in usecallback
-  const onClickChatListItem = (chat: GraphChatThread) => {
-    chatListClient?.setSelectedChat(chat);
-  };
+  const onClickChatListItem = useCallback(
+    (chat: GraphChatThread) => {
+      if (chatListClient) {
+        chatListClient.setSelectedChat(chat);
+      }
+    },
+    [chatListClient]
+  );
 
   const chatListButtonItems = props.buttonItems === undefined ? [] : props.buttonItems;
   const chatListMenuItems = props.menuItems === undefined ? [] : props.menuItems;
@@ -295,15 +296,9 @@ export const ChatList = ({
     <FluentThemeProvider fluentTheme={FluentTheme}>
       <FluentProvider theme={webLightTheme} className={styles.fullHeight}>
         <div className={styles.chatList}>
-          {Providers.globalProvider?.state === ProviderState.SignedIn &&
-            chatListState?.status !== 'server connection lost' &&
-            chatListActions && (
-              <ChatListHeader
-                actions={chatListActions}
-                buttonItems={chatListButtonItems}
-                menuItems={chatListMenuItems}
-              />
-            )}
+          {chatListState?.status !== 'server connection lost' && chatListActions && (
+            <ChatListHeader actions={chatListActions} buttonItems={chatListButtonItems} menuItems={chatListMenuItems} />
+          )}
           {chatListState && chatListState.chatThreads.length > 0 ? (
             <>
               <div className={styles.scrollbox}>
@@ -330,7 +325,6 @@ export const ChatList = ({
           ) : (
             <>
               <div className={styles.error}>
-                {!chatListState?.userId && <Error message="User not signed-in." subheading={PleaseSignIn}></Error>}
                 {isLoading && (
                   <div className={styles.spinner}>
                     <Spinner /> <br />

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -106,16 +106,16 @@ export const ChatList = ({
 }: MgtTemplateProps & IChatListProps & IChatListMenuItemsProps) => {
   const styles = useStyles();
   const chatListClient = useMemo(() => new StatefulGraphChatListClient(), []);
+  const chatListActions = useMemo(() => {
+    return {
+      markAllChatThreadsAsRead: () => chatListClient.markAllChatThreadsAsRead()
+    } as IChatListActions;
+  }, [chatListClient]);
   const [initialLastReadTimeInterval, setInitialLastReadTimeInterval] = useState<number | undefined>();
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
-  const [chatListActions, setChatListActions] = useState<IChatListActions | undefined>();
 
   useEffect(() => {
     chatListClient.onStateChange(setChatListState);
-
-    setChatListActions({
-      markAllChatThreadsAsRead: () => chatListClient.markAllChatThreadsAsRead()
-    });
     return () => {
       chatListClient.offStateChange(setChatListState);
     };

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -105,12 +105,12 @@ export const ChatList = ({
   ...props
 }: MgtTemplateProps & IChatListProps & IChatListMenuItemsProps) => {
   const styles = useStyles();
-  const chatListClient = useMemo(() => new StatefulGraphChatListClient(), []);
-  const chatListActions = useMemo(() => {
+  const [chatListClient] = useState<StatefulGraphChatListClient>(() => new StatefulGraphChatListClient());
+  const [chatListActions] = useState<IChatListActions>(() => {
     return {
       markAllChatThreadsAsRead: () => chatListClient.markAllChatThreadsAsRead()
-    } as IChatListActions;
-  }, [chatListClient]);
+    };
+  });
   const [initialLastReadTimeInterval, setInitialLastReadTimeInterval] = useState<number | undefined>();
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
 

--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { ChatListItem } from '../ChatListItem/ChatListItem';
-import { MgtTemplateProps, ProviderState, Providers, Spinner, log, error } from '@microsoft/mgt-react';
+import { MgtTemplateProps, Spinner, log, error } from '@microsoft/mgt-react';
 import { makeStyles, Button, FluentProvider, shorthands, webLightTheme } from '@fluentui/react-components';
 import { FluentThemeProvider } from '@azure/communication-react';
 import { FluentTheme } from '@fluentui/react';
@@ -111,20 +111,12 @@ export const ChatList = ({
   const [chatListState, setChatListState] = useState<GraphChatListClient | undefined>();
   const [chatListActions, setChatListActions] = useState<IChatListActions | undefined>();
 
-  // wait for provider to be ready before setting client and state
   useEffect(() => {
-    const provider = Providers.globalProvider;
-    const conditionalLoad = (state: ProviderState | undefined) => {
-      if (!chatListClient) {
-        const client = new StatefulGraphChatListClient();
-        client.onStateChange(setChatListState);
-        setChatListClient(client);
-      }
-    };
-    provider?.onStateChanged(evt => {
-      conditionalLoad(evt.detail);
-    });
-    conditionalLoad(provider?.state);
+    if (!chatListClient) {
+      const client = new StatefulGraphChatListClient();
+      client.onStateChange(setChatListState);
+      setChatListClient(client);
+    }
   }, [chatListClient]);
 
   useEffect(() => {

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -8,7 +8,7 @@ import {
   TeamworkApplicationIdentity,
   TeamsAppInstallation
 } from '@microsoft/microsoft-graph-types';
-import { ProviderState, Providers, error } from '@microsoft/mgt-element';
+import { Providers, error } from '@microsoft/mgt-element';
 import { rewriteEmojiContentToText } from '../../utils/rewriteEmojiContent';
 import { convert } from 'html-to-text';
 import { loadBotsInChat } from '../../statefulClient/graph.chat';
@@ -143,11 +143,7 @@ export const ChatListItem = ({ chat, userId: myId, isSelected, isRead }: IChatLi
       return;
     }
 
-    // make sure there is a logged in graph provider
     const provider = Providers.globalProvider;
-    if (!provider || provider.state !== ProviderState.SignedIn) {
-      return;
-    }
 
     // set to loading
     isBotsLoadingOrLoaded.current = true;

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -63,6 +63,7 @@ export class GraphNotificationUserClient {
   private wasConnected?: boolean | undefined;
   private userId = '';
   private lastNotificationUrl = '';
+  private subscriptionId = '';
 
   private readonly subscriptionCache: SubscriptionsCache = new SubscriptionsCache();
   private readonly timer = new Timer();
@@ -106,7 +107,14 @@ export class GraphNotificationUserClient {
   private readonly receiveNotificationMessage = (message: string) => {
     if (typeof message !== 'string') throw new Error('Expected string from receivenotificationmessageasync');
 
+    const ackMessage: unknown = { StatusCode: '200' };
     const notification: ReceivedNotification = JSON.parse(message) as ReceivedNotification;
+    // only process notifications for the current subscription
+    if (this.subscriptionId && this.subscriptionId !== notification.subscriptionId) {
+      log('Received notification for a different subscription', notification);
+      return ackMessage;
+    }
+
     log('received user notification message', notification);
     const emitter: ThreadEventEmitter | undefined = this.emitter;
     if (!notification.resourceData) throw new Error('Message did not contain resourceData');
@@ -118,7 +126,6 @@ export class GraphNotificationUserClient {
       this.processChatPropertiesNotification(notification, emitter);
     }
     // Need to return a status code string of 200 so that graph knows the message was received and doesn't re-send the notification
-    const ackMessage: unknown = { StatusCode: '200' };
     return GraphConfig.ackAsString ? JSON.stringify(ackMessage) : ackMessage;
   };
 
@@ -204,6 +211,7 @@ export class GraphNotificationUserClient {
     if (!subscription?.notificationUrl) throw new Error('Subscription not created');
     log(subscription);
 
+    this.subscriptionId = subscription.id!;
     await this.cacheSubscription(userId, subscription);
 
     log('Subscription created.');
@@ -215,6 +223,7 @@ export class GraphNotificationUserClient {
     try {
       log('Removing all user subscriptions from cache...');
       await this.subscriptionCache.deleteCachedSubscriptions(userId);
+      this.subscriptionId = '';
       log('Successfully removed all user subscriptions from cache.');
     } catch (e) {
       error('Failed to remove all user subscriptions from cache.', e);

--- a/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationUserClient.ts
@@ -240,7 +240,7 @@ export class GraphNotificationUserClient {
 
   private trySwitchToDisconnected() {
     if (this.wasConnected) {
-      log('The user can no receive notifications from the user subscription.');
+      log('The user can now receive notifications from the user subscription.');
       this.wasConnected = false;
       this.emitter?.disconnected();
     }

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -110,10 +110,6 @@ interface StatefulClient<T> {
    */
   chatThreadsPerPage: number;
   /**
-   * Method for setting to a fatal error condition
-   */
-  raiseFatalError(e: Error): void;
-  /**
    * Method for loading more chat threads
    */
   tryLoadChatThreads(): void;
@@ -224,7 +220,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   /**
    * Switches to a fatal error state and logs the error.
    */
-  public raiseFatalError(e: Error) {
+  private raiseFatalError(e: Error) {
     error(e);
     this.notifyStateChange((draft: GraphChatListClient) => {
       draft.status = 'fatal error';
@@ -840,6 +836,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
       this.notifyStateChange((draft: GraphChatListClient) => {
         draft.status = 'server connection established';
       });
+      void this.tryLoadChatThreads().catch(e => this.raiseFatalError(e as Error));
     });
   }
 }

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import './App.css';
 import { Login } from '@microsoft/mgt-react';
 import { Chat, ChatList, NewChat, ChatListButtonItem, ChatListMenuItem, IChatListActions } from '@microsoft/mgt-chat';
 import { ChatMessage, Chat as GraphChat } from '@microsoft/microsoft-graph-types';
 import { Compose24Filled, Compose24Regular, bundleIcon } from '@fluentui/react-icons';
 import { GraphChatThread } from '../../../packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient';
+import { Providers, ProviderState } from '@microsoft/mgt-element';
 
 const ChatAddIconBundle = bundleIcon(Compose24Filled, Compose24Regular);
 
@@ -13,10 +14,31 @@ export const ChatAddIcon = (): JSX.Element => {
   return <ChatAddIconBundle color={iconColor} />;
 };
 
+function useIsSignedIn(): [boolean] {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  useEffect(() => {
+    const updateState = () => {
+      const provider = Providers.globalProvider;
+      setIsSignedIn(provider && provider.state === ProviderState.SignedIn);
+    };
+
+    Providers.onProviderUpdated(updateState);
+    updateState();
+
+    return () => {
+      Providers.removeProviderUpdatedListener(updateState);
+    };
+  }, []);
+
+  return [isSignedIn];
+}
+
 function App() {
   let sessionChatId = sessionStorage.getItem('chatId') ?? '';
   console.log('sessionChatId: ', sessionChatId);
 
+  const [isSignedIn] = useIsSignedIn();
   const [chatId, setChatId] = useState<string>(sessionChatId);
   const [chatThreadsPerPage, setChatThreadsPerPage] = useState<number>(10);
   const [showNewChat, setShowNewChat] = useState<boolean>(false);
@@ -129,18 +151,20 @@ function App() {
           )}
         </div>
         <div className="chatlist-pane">
-          <ChatList
-            selectedChatId={chatId}
-            onLoaded={onLoaded}
-            chatThreadsPerPage={chatThreadsPerPage}
-            menuItems={menus}
-            buttonItems={buttons}
-            onSelected={onChatSelected}
-            onMessageReceived={onMessageReceived}
-            onAllMessagesRead={onAllMessagesRead}
-            onConnectionChanged={onConnectionChanged}
-            onUnselected={onUnselected}
-          />
+          {isSignedIn && (
+            <ChatList
+              selectedChatId={chatId}
+              onLoaded={onLoaded}
+              chatThreadsPerPage={chatThreadsPerPage}
+              menuItems={menus}
+              buttonItems={buttons}
+              onSelected={onChatSelected}
+              onMessageReceived={onMessageReceived}
+              onAllMessagesRead={onAllMessagesRead}
+              onConnectionChanged={onConnectionChanged}
+              onUnselected={onUnselected}
+            />
+          )}
         </div>
         {/* NOTE: removed the chatId guard as this case has an error state. */}
         <div className="chat-pane">{<Chat chatId={selectedChatListChatId} />}</div>

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -45,7 +45,7 @@ function App() {
   // we are using a different state to track the selected chat id fired from chat list.
   const [selectedChatListChatId, setSelectedChatListChatId] = useState<string>('');
 
-  sessionStorage.clear();
+  sessionStorage.removeItem('chatId');
 
   const saveChatAndRefresh = () => {
     if (chatId !== '') {

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -20,7 +20,7 @@ function useIsSignedIn(): [boolean] {
   useEffect(() => {
     const updateState = () => {
       const provider = Providers.globalProvider;
-      setIsSignedIn(provider && provider.state === ProviderState.SignedIn);
+      setIsSignedIn(provider?.state === ProviderState.SignedIn);
     };
 
     Providers.onProviderUpdated(updateState);

--- a/samples/react-chat/src/index.tsx
+++ b/samples/react-chat/src/index.tsx
@@ -13,7 +13,7 @@ brokerSettings.renewalTimerInterval = 15;
 
 Providers.globalProvider = new Msal2Provider({
   baseURL: GraphConfig.graphEndpoint,
-  clientId: 'ed072e38-e76e-45ae-ab76-073cb95495bb',
+  clientId: '5ef01fb1-fc01-4999-a90e-24de21f2ad2f',
   scopes: allChatListScopes
 });
 

--- a/samples/react-chat/src/index.tsx
+++ b/samples/react-chat/src/index.tsx
@@ -13,7 +13,7 @@ brokerSettings.renewalTimerInterval = 15;
 
 Providers.globalProvider = new Msal2Provider({
   baseURL: GraphConfig.graphEndpoint,
-  clientId: '5ef01fb1-fc01-4999-a90e-24de21f2ad2f',
+  clientId: 'ed072e38-e76e-45ae-ab76-073cb95495bb',
   scopes: allChatListScopes
 });
 

--- a/samples/react-contoso/src/pages/ChatPage.tsx
+++ b/samples/react-contoso/src/pages/ChatPage.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback } from 'react';
 import { PageHeader } from '../components/PageHeader';
 import { shorthands, makeStyles, Dialog, DialogSurface, DialogBody, DialogTitle } from '@fluentui/react-components';
 import { Chat as GraphChat, ChatMessage } from '@microsoft/microsoft-graph-types';
 import { ChatList, Chat, NewChat, ChatListButtonItem, ChatListMenuItem, IChatListActions } from '@microsoft/mgt-chat';
 import { Compose24Filled, Compose24Regular, bundleIcon } from '@fluentui/react-icons';
 import { GraphChatThread } from '../../../../packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient';
-import { Providers, ProviderState } from '@microsoft/mgt-element';
+import { useIsSignedIn } from '../hooks/useIsSignedIn';
 
 const ChatAddIconBundle = bundleIcon(Compose24Filled, Compose24Regular);
 
@@ -14,26 +14,6 @@ export const ChatAddIcon = (): JSX.Element => {
   const iconColor = 'var(--colorBrandForeground2)';
   return <ChatAddIconBundle color={iconColor} />;
 };
-
-function useIsSignedIn(): [boolean] {
-  const [isSignedIn, setIsSignedIn] = useState(false);
-
-  useEffect(() => {
-    const updateState = () => {
-      const provider = Providers.globalProvider;
-      setIsSignedIn(provider && provider.state === ProviderState.SignedIn);
-    };
-
-    Providers.onProviderUpdated(updateState);
-    updateState();
-
-    return () => {
-      Providers.removeProviderUpdatedListener(updateState);
-    };
-  }, []);
-
-  return [isSignedIn];
-}
 
 const useStyles = makeStyles({
   container: {


### PR DESCRIPTION
This PR addresses some comments from Gavin on ChatList:

Completed:

- todo: ChatList no longer references sign-in state to execute any logic.
- todo: ChatListState state var is now only handler subscribed to statefulgraphchatlistclient state changes. UseEffect now relies on updates to ChatListState.
- todo: implement offStateChange 
- todo: add doc to indicate why we are not adding deps
- "todo": remove sign-in state check from chatlistItem
