### PR TITLE
[BUGFIX] New chats created by a user should be READ for them.

### DIFF
--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -638,7 +638,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
           id: event.message.chatId,
           lastMessagePreview: event.message as ChatMessageInfo,
           lastUpdatedDateTime: event.message.lastModifiedDateTime,
-          isRead: false
+          isRead: this.userId === event.message.from?.user?.id
         };
         draft.chatThreads.unshift(newChatThread);
         // async load more info


### PR DESCRIPTION
isRead was always FALSE on new chat threads coming in instead of checking to see who the last message was from.