### PR TITLE
[BUGFIX] Fixed issue whereby server connection established was overridden

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -208,12 +208,22 @@ export const ChatList = ({
 
     if (chatListState.status === 'server connection established' && onConnectionChanged) {
       onConnectionChanged(true);
+      void chatListClient.tryLoadChatThreads().catch(e => chatListClient.raiseFatalError(e as Error));
     }
 
     if (chatListState.status === 'server connection lost' && onConnectionChanged) {
       onConnectionChanged(false);
     }
-  }, [chatListState, onLoaded, onMessageReceived, onSelected, onUnselected, onAllMessagesRead, onConnectionChanged]);
+  }, [
+    chatListClient,
+    chatListState,
+    onLoaded,
+    onMessageReceived,
+    onSelected,
+    onUnselected,
+    onAllMessagesRead,
+    onConnectionChanged
+  ]);
 
   // this only runs once when the component is unmounted
   useEffect(() => {

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -221,7 +221,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   /**
    * Switches to a fatal error state and logs the error.
    */
-  private raiseFatalError(e: Error) {
+  public raiseFatalError(e: Error) {
     error(e);
     this.notifyStateChange((draft: GraphChatListClient) => {
       draft.status = 'fatal error';
@@ -852,7 +852,6 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
       this.notifyStateChange((draft: GraphChatListClient) => {
         draft.status = 'server connection established';
       });
-      void this.tryLoadChatThreads().catch(e => this.raiseFatalError(e as Error));
     });
   }
 }


### PR DESCRIPTION
This PR ensures that "server connection established" fires before any attempt to load chats.