### PR TITLE
Fix refresh issues with ChatList selection

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { ChatListItem } from '../ChatListItem/ChatListItem';
 import { MgtTemplateProps, Spinner, log, error } from '@microsoft/mgt-react';
 import { makeStyles, Button, FluentProvider, shorthands, webLightTheme } from '@fluentui/react-components';

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -135,7 +135,7 @@ export const ChatListItem = ({ chat, userId: myId, isSelected, isRead }: IChatLi
   useEffect(() => {
     setBots(undefined);
     isBotsLoadingOrLoaded.current = false;
-  }, [chat]);
+  }, [chat.id]);
 
   const startLoadingBotsInChat = async (chatId: string) => {
     // ensure this is only called once

--- a/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
+++ b/packages/mgt-chat/src/components/ChatListItem/ChatListItem.tsx
@@ -135,7 +135,7 @@ export const ChatListItem = ({ chat, userId: myId, isSelected, isRead }: IChatLi
   useEffect(() => {
     setBots(undefined);
     isBotsLoadingOrLoaded.current = false;
-  }, [chat.id]);
+  }, [chat?.id]);
 
   const startLoadingBotsInChat = async (chatId: string) => {
     // ensure this is only called once


### PR DESCRIPTION
Prior to this PR, selecting a 1:1 chat with a bot would flash the wrong name. This is because the useEffect for clearing the cache was based on a change of chat. However, since the isRead flag is being changed each time there is a selection, this was constantly firing.