### PR TITLE
Prevent duplicated ChatList events

### DIFF
--- a/packages/mgt-chat/src/components/ChatList/ChatList.tsx
+++ b/packages/mgt-chat/src/components/ChatList/ChatList.tsx
@@ -116,11 +116,11 @@ export const ChatList = ({
 
   useEffect(() => {
     const handleStateChange = (newState: GraphChatListClient | undefined) => {
+      setChatListState(newState);
+
       if (!newState) {
         return;
       }
-
-      setChatListState(newState);
 
       // handle state changes
       if (newState.status === 'chat message received' && onMessageReceived && newState.chatMessage) {

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatListClient.ts
@@ -184,7 +184,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   private readonly _eventEmitter: ThreadEventEmitter;
   private readonly _cache: LastReadCache;
   private readonly _graph: IGraph;
-  private _stateSubscribers: ((state: GraphChatListClient) => void)[] = [];
+  private readonly _stateSubscribers: ((state: GraphChatListClient) => void)[] = [];
   private _initialSelectedChatId: string | undefined;
   private _loadPromise: Promise<void> | undefined;
   private _loadMorePromise: Promise<void> | undefined;
@@ -521,7 +521,7 @@ class StatefulGraphChatListClient implements StatefulClient<GraphChatListClient>
   public offStateChange(handler: (state: GraphChatListClient) => void): void {
     const index = this._stateSubscribers.indexOf(handler);
     if (index !== -1) {
-      this._stateSubscribers = this._stateSubscribers.splice(index, 1);
+      this._stateSubscribers.splice(index, 1);
     }
   }
 


### PR DESCRIPTION
Prevent ChatList from generating duplicate events.

A duplicate event is being thrown any time one of the callback functions gets recreated. In the previous version of the code, the `useEffect` would trigger off of any change to any callback and would preprocess the event as if it had just come in. Now, events will only processed if they are generated by the `StatefulGraphChatListClient`.

Additionally, the `StatefulGraphChatListClient` was not removing handlers during the `offStateChange()`. (`splice()` returns what was removed, so the handler that was being removed from `_subscribers` was being added back.)

**Steps to validate behavior:**

Update `onMessageReceived` in `samples\react-chat\src\App.tsx` to be:
```
  const onMessageReceived = useCallback((msg: ChatMessage) => {
    console.log('SampleChatLog: Message received', msg, chatThreadsPerPage);
  }, [chatThreadsPerPage]);
```

Run the demo app using `yarn watch:chat`.

Open the Dev Tools and view the console.

From another user, send a message to the sample application.

Switch the "Number of Chat Threads per Page" drowdown.

**Old behavior:**

- Initial message sent from other user would trigger twice.
- Each time the drop down was changed, the message would trigger again.

**New behavior:**

- Initial message sent from other user would trigger only once.
- Changing the drop down does not re-trigger the message.
